### PR TITLE
Anchor tags options

### DIFF
--- a/README.md
+++ b/README.md
@@ -135,7 +135,7 @@ TIP: The default slot only renders **once** at the beginning, and it will overwr
 | toc-anchor-link-symbol | String | `#` | customize the anchor link symbol |
 | toc-anchor-link-space | Boolean | `true` | enable inserting a space between the anchor link and heading |
 | toc-anchor-link-class | String | `toc-anchor-link` | customize the anchor link symbol class name |
-| anchorAttributes | Object | {} | anchor tag attributes such as `target: '_blank'` or `rel: 'nofollow'` |
+| anchorAttributes | Object | `{}` | anchor tag attributes such as `target: '_blank'` or `rel: 'nofollow'` |
 | prerender | Function (String) String | `null` | filter function before markdown parse |
 | postrender | Function (String) String | `null` | filter function after markdown parse |
 

--- a/README.md
+++ b/README.md
@@ -102,7 +102,7 @@ new Vue({
 <vue-markdown>this is the default slot</vue-markdown>
 ```
 
-After setting up the middleware in your vue component above, using the embedded markdown is as easy as writing it between the `vue-markdown` tags. 
+After setting up the middleware in your vue component above, using the embedded markdown is as easy as writing it between the `vue-markdown` tags.
 
 VueMarkdown has a default slot which is used to write the `markdown` source.
 
@@ -135,7 +135,7 @@ TIP: The default slot only renders **once** at the beginning, and it will overwr
 | toc-anchor-link-symbol | String | `#` | customize the anchor link symbol |
 | toc-anchor-link-space | Boolean | `true` | enable inserting a space between the anchor link and heading |
 | toc-anchor-link-class | String | `toc-anchor-link` | customize the anchor link symbol class name |
-| open-link-newtab | Boolean | `true` | enable open link in new tab |
+| anchorAttributes | Object | {} | anchor tag attributes such as `target: '_blank'` or `rel: 'nofollow'` |
 | prerender | Function (String) String | `null` | filter function before markdown parse |
 | postrender | Function (String) String | `null` | filter function after markdown parse |
 

--- a/README.md
+++ b/README.md
@@ -160,6 +160,7 @@ TIP: The default slot only renders **once** at the beginning, and it will overwr
 - [nikolasp](https://github.com/nikolasp)
 - [mbackonja](https://github.com/mbackonja)
 - [Endi1](https://github.com/Endi1)
+- [printscreen](https://github.com/printscreen)
 
 # License
 

--- a/dist/vue-markdown.common.js
+++ b/dist/vue-markdown.common.js
@@ -1,5 +1,5 @@
 /**
- * vue-markdown v2.1.4
+ * vue-markdown v2.2.1
  * https://github.com/miaolz123/vue-markdown
  * MIT License
  */

--- a/dist/vue-markdown.common.js
+++ b/dist/vue-markdown.common.js
@@ -6,14 +6,14 @@
 
 (function webpackUniversalModuleDefinition(root, factory) {
 	if(typeof exports === 'object' && typeof module === 'object')
-		module.exports = factory(require("babel-runtime/core-js/get-iterator"), require("markdown-it"), require("markdown-it-emoji"), require("markdown-it-sub"), require("markdown-it-sup"), require("markdown-it-footnote"), require("markdown-it-deflist"), require("markdown-it-abbr"), require("markdown-it-ins"), require("markdown-it-mark"), require("markdown-it-toc-and-anchor"), require("markdown-it-katex"), require("markdown-it-highlightjs"));
+		module.exports = factory(require("babel-runtime/core-js/get-iterator"), require("babel-runtime/core-js/object/keys"), require("markdown-it"), require("markdown-it-emoji"), require("markdown-it-sub"), require("markdown-it-sup"), require("markdown-it-footnote"), require("markdown-it-deflist"), require("markdown-it-abbr"), require("markdown-it-ins"), require("markdown-it-mark"), require("markdown-it-toc-and-anchor"), require("markdown-it-katex"), require("markdown-it-highlightjs"));
 	else if(typeof define === 'function' && define.amd)
-		define(["babel-runtime/core-js/get-iterator", "markdown-it", "markdown-it-emoji", "markdown-it-sub", "markdown-it-sup", "markdown-it-footnote", "markdown-it-deflist", "markdown-it-abbr", "markdown-it-ins", "markdown-it-mark", "markdown-it-toc-and-anchor", "markdown-it-katex", "markdown-it-highlightjs"], factory);
+		define(["babel-runtime/core-js/get-iterator", "babel-runtime/core-js/object/keys", "markdown-it", "markdown-it-emoji", "markdown-it-sub", "markdown-it-sup", "markdown-it-footnote", "markdown-it-deflist", "markdown-it-abbr", "markdown-it-ins", "markdown-it-mark", "markdown-it-toc-and-anchor", "markdown-it-katex", "markdown-it-highlightjs"], factory);
 	else if(typeof exports === 'object')
-		exports["VueMarkdown"] = factory(require("babel-runtime/core-js/get-iterator"), require("markdown-it"), require("markdown-it-emoji"), require("markdown-it-sub"), require("markdown-it-sup"), require("markdown-it-footnote"), require("markdown-it-deflist"), require("markdown-it-abbr"), require("markdown-it-ins"), require("markdown-it-mark"), require("markdown-it-toc-and-anchor"), require("markdown-it-katex"), require("markdown-it-highlightjs"));
+		exports["VueMarkdown"] = factory(require("babel-runtime/core-js/get-iterator"), require("babel-runtime/core-js/object/keys"), require("markdown-it"), require("markdown-it-emoji"), require("markdown-it-sub"), require("markdown-it-sup"), require("markdown-it-footnote"), require("markdown-it-deflist"), require("markdown-it-abbr"), require("markdown-it-ins"), require("markdown-it-mark"), require("markdown-it-toc-and-anchor"), require("markdown-it-katex"), require("markdown-it-highlightjs"));
 	else
-		root["VueMarkdown"] = factory(root["babel-runtime/core-js/get-iterator"], root["markdown-it"], root["markdown-it-emoji"], root["markdown-it-sub"], root["markdown-it-sup"], root["markdown-it-footnote"], root["markdown-it-deflist"], root["markdown-it-abbr"], root["markdown-it-ins"], root["markdown-it-mark"], root["markdown-it-toc-and-anchor"], root["markdown-it-katex"], root["markdown-it-highlightjs"]);
-})(this, function(__WEBPACK_EXTERNAL_MODULE_1__, __WEBPACK_EXTERNAL_MODULE_2__, __WEBPACK_EXTERNAL_MODULE_3__, __WEBPACK_EXTERNAL_MODULE_4__, __WEBPACK_EXTERNAL_MODULE_5__, __WEBPACK_EXTERNAL_MODULE_6__, __WEBPACK_EXTERNAL_MODULE_7__, __WEBPACK_EXTERNAL_MODULE_8__, __WEBPACK_EXTERNAL_MODULE_9__, __WEBPACK_EXTERNAL_MODULE_10__, __WEBPACK_EXTERNAL_MODULE_11__, __WEBPACK_EXTERNAL_MODULE_12__, __WEBPACK_EXTERNAL_MODULE_13__) {
+		root["VueMarkdown"] = factory(root["babel-runtime/core-js/get-iterator"], root["babel-runtime/core-js/object/keys"], root["markdown-it"], root["markdown-it-emoji"], root["markdown-it-sub"], root["markdown-it-sup"], root["markdown-it-footnote"], root["markdown-it-deflist"], root["markdown-it-abbr"], root["markdown-it-ins"], root["markdown-it-mark"], root["markdown-it-toc-and-anchor"], root["markdown-it-katex"], root["markdown-it-highlightjs"]);
+})(this, function(__WEBPACK_EXTERNAL_MODULE_1__, __WEBPACK_EXTERNAL_MODULE_2__, __WEBPACK_EXTERNAL_MODULE_3__, __WEBPACK_EXTERNAL_MODULE_4__, __WEBPACK_EXTERNAL_MODULE_5__, __WEBPACK_EXTERNAL_MODULE_6__, __WEBPACK_EXTERNAL_MODULE_7__, __WEBPACK_EXTERNAL_MODULE_8__, __WEBPACK_EXTERNAL_MODULE_9__, __WEBPACK_EXTERNAL_MODULE_10__, __WEBPACK_EXTERNAL_MODULE_11__, __WEBPACK_EXTERNAL_MODULE_12__, __WEBPACK_EXTERNAL_MODULE_13__, __WEBPACK_EXTERNAL_MODULE_14__) {
 return /******/ (function(modules) { // webpackBootstrap
 /******/ 	// The module cache
 /******/ 	var installedModules = {};
@@ -70,51 +70,55 @@ return /******/ (function(modules) { // webpackBootstrap
 
 	var _getIterator3 = _interopRequireDefault(_getIterator2);
 
-	var _markdownIt = __webpack_require__(2);
+	var _keys = __webpack_require__(2);
+
+	var _keys2 = _interopRequireDefault(_keys);
+
+	var _markdownIt = __webpack_require__(3);
 
 	var _markdownIt2 = _interopRequireDefault(_markdownIt);
 
-	var _markdownItEmoji = __webpack_require__(3);
+	var _markdownItEmoji = __webpack_require__(4);
 
 	var _markdownItEmoji2 = _interopRequireDefault(_markdownItEmoji);
 
-	var _markdownItSub = __webpack_require__(4);
+	var _markdownItSub = __webpack_require__(5);
 
 	var _markdownItSub2 = _interopRequireDefault(_markdownItSub);
 
-	var _markdownItSup = __webpack_require__(5);
+	var _markdownItSup = __webpack_require__(6);
 
 	var _markdownItSup2 = _interopRequireDefault(_markdownItSup);
 
-	var _markdownItFootnote = __webpack_require__(6);
+	var _markdownItFootnote = __webpack_require__(7);
 
 	var _markdownItFootnote2 = _interopRequireDefault(_markdownItFootnote);
 
-	var _markdownItDeflist = __webpack_require__(7);
+	var _markdownItDeflist = __webpack_require__(8);
 
 	var _markdownItDeflist2 = _interopRequireDefault(_markdownItDeflist);
 
-	var _markdownItAbbr = __webpack_require__(8);
+	var _markdownItAbbr = __webpack_require__(9);
 
 	var _markdownItAbbr2 = _interopRequireDefault(_markdownItAbbr);
 
-	var _markdownItIns = __webpack_require__(9);
+	var _markdownItIns = __webpack_require__(10);
 
 	var _markdownItIns2 = _interopRequireDefault(_markdownItIns);
 
-	var _markdownItMark = __webpack_require__(10);
+	var _markdownItMark = __webpack_require__(11);
 
 	var _markdownItMark2 = _interopRequireDefault(_markdownItMark);
 
-	var _markdownItTocAndAnchor = __webpack_require__(11);
+	var _markdownItTocAndAnchor = __webpack_require__(12);
 
 	var _markdownItTocAndAnchor2 = _interopRequireDefault(_markdownItTocAndAnchor);
 
-	var _markdownItKatex = __webpack_require__(12);
+	var _markdownItKatex = __webpack_require__(13);
 
 	var _markdownItKatex2 = _interopRequireDefault(_markdownItKatex);
 
-	var _markdownItHighlightjs = __webpack_require__(13);
+	var _markdownItHighlightjs = __webpack_require__(14);
 
 	var _markdownItHighlightjs2 = _interopRequireDefault(_markdownItHighlightjs);
 
@@ -225,9 +229,9 @@ return /******/ (function(modules) { // webpackBootstrap
 	      type: String,
 	      default: 'toc-anchor-link'
 	    },
-	    openLinkNewtab: {
-	      type: Boolean,
-	      default: true
+	    anchorAttributes: {
+	      type: Object,
+	      default: {}
 	    },
 	    prerender: {
 	      type: Function,
@@ -278,18 +282,15 @@ return /******/ (function(modules) { // webpackBootstrap
 	      return self.renderToken(tokens, idx, options);
 	    };
 	    this.md.renderer.rules.link_open = function (tokens, idx, options, env, self) {
-	      if (!_this.openLinkNewtab) {
-	        return defaultLinkRenderer(tokens, idx, options, env, self);
-	      }
-
-	      var aIndex = tokens[idx].attrIndex('target');
-
-	      if (aIndex < 0) {
-	        tokens[idx].attrPush(['target', '_blank']); // add new attribute
-	      } else {
-	        tokens[idx].attrs[aIndex][1] = '_blank';
-	      }
-
+	      (0, _keys2.default)(_this.anchorAttributes).map(function (attribute) {
+	        var aIndex = tokens[idx].attrIndex(attribute);
+	        var value = _this.anchorAttributes[attribute];
+	        if (aIndex < 0) {
+	          tokens[idx].attrPush([attribute, value]); // add new attribute
+	        } else {
+	          tokens[idx].attrs[aIndex][1] = value;
+	        }
+	      });
 	      return defaultLinkRenderer(tokens, idx, options, env, self);
 	    };
 
@@ -446,6 +447,12 @@ return /******/ (function(modules) { // webpackBootstrap
 /***/ (function(module, exports) {
 
 	module.exports = __WEBPACK_EXTERNAL_MODULE_13__;
+
+/***/ }),
+/* 14 */
+/***/ (function(module, exports) {
+
+	module.exports = __WEBPACK_EXTERNAL_MODULE_14__;
 
 /***/ })
 /******/ ])

--- a/dist/vue-markdown.js
+++ b/dist/vue-markdown.js
@@ -1,5 +1,5 @@
 /**
- * vue-markdown v2.1.4
+ * vue-markdown v2.2.1
  * https://github.com/miaolz123/vue-markdown
  * MIT License
  */
@@ -91,51 +91,55 @@ return /******/ (function(modules) { // webpackBootstrap
 
 	var _getIterator3 = _interopRequireDefault(_getIterator2);
 
-	var _markdownIt = __webpack_require__(55);
+	var _keys = __webpack_require__(55);
+
+	var _keys2 = _interopRequireDefault(_keys);
+
+	var _markdownIt = __webpack_require__(59);
 
 	var _markdownIt2 = _interopRequireDefault(_markdownIt);
 
-	var _markdownItEmoji = __webpack_require__(123);
+	var _markdownItEmoji = __webpack_require__(127);
 
 	var _markdownItEmoji2 = _interopRequireDefault(_markdownItEmoji);
 
-	var _markdownItSub = __webpack_require__(129);
+	var _markdownItSub = __webpack_require__(133);
 
 	var _markdownItSub2 = _interopRequireDefault(_markdownItSub);
 
-	var _markdownItSup = __webpack_require__(130);
+	var _markdownItSup = __webpack_require__(134);
 
 	var _markdownItSup2 = _interopRequireDefault(_markdownItSup);
 
-	var _markdownItFootnote = __webpack_require__(131);
+	var _markdownItFootnote = __webpack_require__(135);
 
 	var _markdownItFootnote2 = _interopRequireDefault(_markdownItFootnote);
 
-	var _markdownItDeflist = __webpack_require__(132);
+	var _markdownItDeflist = __webpack_require__(136);
 
 	var _markdownItDeflist2 = _interopRequireDefault(_markdownItDeflist);
 
-	var _markdownItAbbr = __webpack_require__(133);
+	var _markdownItAbbr = __webpack_require__(137);
 
 	var _markdownItAbbr2 = _interopRequireDefault(_markdownItAbbr);
 
-	var _markdownItIns = __webpack_require__(134);
+	var _markdownItIns = __webpack_require__(138);
 
 	var _markdownItIns2 = _interopRequireDefault(_markdownItIns);
 
-	var _markdownItMark = __webpack_require__(135);
+	var _markdownItMark = __webpack_require__(139);
 
 	var _markdownItMark2 = _interopRequireDefault(_markdownItMark);
 
-	var _markdownItTocAndAnchor = __webpack_require__(136);
+	var _markdownItTocAndAnchor = __webpack_require__(140);
 
 	var _markdownItTocAndAnchor2 = _interopRequireDefault(_markdownItTocAndAnchor);
 
-	var _markdownItKatex = __webpack_require__(149);
+	var _markdownItKatex = __webpack_require__(153);
 
 	var _markdownItKatex2 = _interopRequireDefault(_markdownItKatex);
 
-	var _markdownItHighlightjs = __webpack_require__(173);
+	var _markdownItHighlightjs = __webpack_require__(177);
 
 	var _markdownItHighlightjs2 = _interopRequireDefault(_markdownItHighlightjs);
 
@@ -246,9 +250,9 @@ return /******/ (function(modules) { // webpackBootstrap
 	      type: String,
 	      default: 'toc-anchor-link'
 	    },
-	    openLinkNewtab: {
-	      type: Boolean,
-	      default: true
+	    anchorAttributes: {
+	      type: Object,
+	      default: {}
 	    },
 	    prerender: {
 	      type: Function,
@@ -299,18 +303,15 @@ return /******/ (function(modules) { // webpackBootstrap
 	      return self.renderToken(tokens, idx, options);
 	    };
 	    this.md.renderer.rules.link_open = function (tokens, idx, options, env, self) {
-	      if (!_this.openLinkNewtab) {
-	        return defaultLinkRenderer(tokens, idx, options, env, self);
-	      }
-
-	      var aIndex = tokens[idx].attrIndex('target');
-
-	      if (aIndex < 0) {
-	        tokens[idx].attrPush(['target', '_blank']); // add new attribute
-	      } else {
-	        tokens[idx].attrs[aIndex][1] = '_blank';
-	      }
-
+	      (0, _keys2.default)(_this.anchorAttributes).map(function (attribute) {
+	        var aIndex = tokens[idx].attrIndex(attribute);
+	        var value = _this.anchorAttributes[attribute];
+	        if (aIndex < 0) {
+	          tokens[idx].attrPush([attribute, value]); // add new attribute
+	        } else {
+	          tokens[idx].attrs[aIndex][1] = value;
+	        }
+	      });
 	      return defaultLinkRenderer(tokens, idx, options, env, self);
 	    };
 
@@ -1237,14 +1238,56 @@ return /******/ (function(modules) { // webpackBootstrap
 /* 55 */
 /***/ (function(module, exports, __webpack_require__) {
 
-	'use strict';
-
-
-	module.exports = __webpack_require__(56);
-
+	module.exports = { "default": __webpack_require__(56), __esModule: true };
 
 /***/ }),
 /* 56 */
+/***/ (function(module, exports, __webpack_require__) {
+
+	__webpack_require__(57);
+	module.exports = __webpack_require__(17).Object.keys;
+
+/***/ }),
+/* 57 */
+/***/ (function(module, exports, __webpack_require__) {
+
+	// 19.1.2.14 Object.keys(O)
+	var toObject = __webpack_require__(49)
+	  , $keys    = __webpack_require__(35);
+
+	__webpack_require__(58)('keys', function(){
+	  return function keys(it){
+	    return $keys(toObject(it));
+	  };
+	});
+
+/***/ }),
+/* 58 */
+/***/ (function(module, exports, __webpack_require__) {
+
+	// most Object methods by ES6 should accept primitives
+	var $export = __webpack_require__(15)
+	  , core    = __webpack_require__(17)
+	  , fails   = __webpack_require__(26);
+	module.exports = function(KEY, exec){
+	  var fn  = (core.Object || {})[KEY] || Object[KEY]
+	    , exp = {};
+	  exp[KEY] = exec(fn);
+	  $export($export.S + $export.F * fails(function(){ fn(1); }), 'Object', exp);
+	};
+
+/***/ }),
+/* 59 */
+/***/ (function(module, exports, __webpack_require__) {
+
+	'use strict';
+
+
+	module.exports = __webpack_require__(60);
+
+
+/***/ }),
+/* 60 */
 /***/ (function(module, exports, __webpack_require__) {
 
 	// Main parser class
@@ -1252,21 +1295,21 @@ return /******/ (function(modules) { // webpackBootstrap
 	'use strict';
 
 
-	var utils        = __webpack_require__(57);
-	var helpers      = __webpack_require__(71);
-	var Renderer     = __webpack_require__(75);
-	var ParserCore   = __webpack_require__(76);
-	var ParserBlock  = __webpack_require__(86);
-	var ParserInline = __webpack_require__(101);
-	var LinkifyIt    = __webpack_require__(116);
-	var mdurl        = __webpack_require__(61);
-	var punycode     = __webpack_require__(118);
+	var utils        = __webpack_require__(61);
+	var helpers      = __webpack_require__(75);
+	var Renderer     = __webpack_require__(79);
+	var ParserCore   = __webpack_require__(80);
+	var ParserBlock  = __webpack_require__(90);
+	var ParserInline = __webpack_require__(105);
+	var LinkifyIt    = __webpack_require__(120);
+	var mdurl        = __webpack_require__(65);
+	var punycode     = __webpack_require__(122);
 
 
 	var config = {
-	  'default': __webpack_require__(120),
-	  zero: __webpack_require__(121),
-	  commonmark: __webpack_require__(122)
+	  'default': __webpack_require__(124),
+	  zero: __webpack_require__(125),
+	  commonmark: __webpack_require__(126)
 	};
 
 	////////////////////////////////////////////////////////////////////////////////
@@ -1827,7 +1870,7 @@ return /******/ (function(modules) { // webpackBootstrap
 
 
 /***/ }),
-/* 57 */
+/* 61 */
 /***/ (function(module, exports, __webpack_require__) {
 
 	// Utilities
@@ -1909,7 +1952,7 @@ return /******/ (function(modules) { // webpackBootstrap
 
 	var DIGITAL_ENTITY_TEST_RE = /^#((?:x[a-f0-9]{1,8}|[0-9]{1,8}))/i;
 
-	var entities = __webpack_require__(58);
+	var entities = __webpack_require__(62);
 
 	function replaceEntityPattern(match, name) {
 	  var code = 0;
@@ -2015,7 +2058,7 @@ return /******/ (function(modules) { // webpackBootstrap
 	////////////////////////////////////////////////////////////////////////////////
 
 	/*eslint-disable max-len*/
-	var UNICODE_PUNCT_RE = __webpack_require__(60);
+	var UNICODE_PUNCT_RE = __webpack_require__(64);
 
 	// Currently without astral characters support.
 	function isPunctChar(ch) {
@@ -2086,8 +2129,8 @@ return /******/ (function(modules) { // webpackBootstrap
 	// bundled size (e.g. a browser build).
 	//
 	exports.lib                 = {};
-	exports.lib.mdurl           = __webpack_require__(61);
-	exports.lib.ucmicro         = __webpack_require__(66);
+	exports.lib.mdurl           = __webpack_require__(65);
+	exports.lib.ucmicro         = __webpack_require__(70);
 
 	exports.assign              = assign;
 	exports.isString            = isString;
@@ -2108,7 +2151,7 @@ return /******/ (function(modules) { // webpackBootstrap
 
 
 /***/ }),
-/* 58 */
+/* 62 */
 /***/ (function(module, exports, __webpack_require__) {
 
 	// HTML5 entities map: { name -> utf16string }
@@ -2116,36 +2159,36 @@ return /******/ (function(modules) { // webpackBootstrap
 	'use strict';
 
 	/*eslint quotes:0*/
-	module.exports = __webpack_require__(59);
+	module.exports = __webpack_require__(63);
 
 
 /***/ }),
-/* 59 */
+/* 63 */
 /***/ (function(module, exports) {
 
 	module.exports = {"Aacute":"Á","aacute":"á","Abreve":"Ă","abreve":"ă","ac":"∾","acd":"∿","acE":"∾̳","Acirc":"Â","acirc":"â","acute":"´","Acy":"А","acy":"а","AElig":"Æ","aelig":"æ","af":"⁡","Afr":"𝔄","afr":"𝔞","Agrave":"À","agrave":"à","alefsym":"ℵ","aleph":"ℵ","Alpha":"Α","alpha":"α","Amacr":"Ā","amacr":"ā","amalg":"⨿","amp":"&","AMP":"&","andand":"⩕","And":"⩓","and":"∧","andd":"⩜","andslope":"⩘","andv":"⩚","ang":"∠","ange":"⦤","angle":"∠","angmsdaa":"⦨","angmsdab":"⦩","angmsdac":"⦪","angmsdad":"⦫","angmsdae":"⦬","angmsdaf":"⦭","angmsdag":"⦮","angmsdah":"⦯","angmsd":"∡","angrt":"∟","angrtvb":"⊾","angrtvbd":"⦝","angsph":"∢","angst":"Å","angzarr":"⍼","Aogon":"Ą","aogon":"ą","Aopf":"𝔸","aopf":"𝕒","apacir":"⩯","ap":"≈","apE":"⩰","ape":"≊","apid":"≋","apos":"'","ApplyFunction":"⁡","approx":"≈","approxeq":"≊","Aring":"Å","aring":"å","Ascr":"𝒜","ascr":"𝒶","Assign":"≔","ast":"*","asymp":"≈","asympeq":"≍","Atilde":"Ã","atilde":"ã","Auml":"Ä","auml":"ä","awconint":"∳","awint":"⨑","backcong":"≌","backepsilon":"϶","backprime":"‵","backsim":"∽","backsimeq":"⋍","Backslash":"∖","Barv":"⫧","barvee":"⊽","barwed":"⌅","Barwed":"⌆","barwedge":"⌅","bbrk":"⎵","bbrktbrk":"⎶","bcong":"≌","Bcy":"Б","bcy":"б","bdquo":"„","becaus":"∵","because":"∵","Because":"∵","bemptyv":"⦰","bepsi":"϶","bernou":"ℬ","Bernoullis":"ℬ","Beta":"Β","beta":"β","beth":"ℶ","between":"≬","Bfr":"𝔅","bfr":"𝔟","bigcap":"⋂","bigcirc":"◯","bigcup":"⋃","bigodot":"⨀","bigoplus":"⨁","bigotimes":"⨂","bigsqcup":"⨆","bigstar":"★","bigtriangledown":"▽","bigtriangleup":"△","biguplus":"⨄","bigvee":"⋁","bigwedge":"⋀","bkarow":"⤍","blacklozenge":"⧫","blacksquare":"▪","blacktriangle":"▴","blacktriangledown":"▾","blacktriangleleft":"◂","blacktriangleright":"▸","blank":"␣","blk12":"▒","blk14":"░","blk34":"▓","block":"█","bne":"=⃥","bnequiv":"≡⃥","bNot":"⫭","bnot":"⌐","Bopf":"𝔹","bopf":"𝕓","bot":"⊥","bottom":"⊥","bowtie":"⋈","boxbox":"⧉","boxdl":"┐","boxdL":"╕","boxDl":"╖","boxDL":"╗","boxdr":"┌","boxdR":"╒","boxDr":"╓","boxDR":"╔","boxh":"─","boxH":"═","boxhd":"┬","boxHd":"╤","boxhD":"╥","boxHD":"╦","boxhu":"┴","boxHu":"╧","boxhU":"╨","boxHU":"╩","boxminus":"⊟","boxplus":"⊞","boxtimes":"⊠","boxul":"┘","boxuL":"╛","boxUl":"╜","boxUL":"╝","boxur":"└","boxuR":"╘","boxUr":"╙","boxUR":"╚","boxv":"│","boxV":"║","boxvh":"┼","boxvH":"╪","boxVh":"╫","boxVH":"╬","boxvl":"┤","boxvL":"╡","boxVl":"╢","boxVL":"╣","boxvr":"├","boxvR":"╞","boxVr":"╟","boxVR":"╠","bprime":"‵","breve":"˘","Breve":"˘","brvbar":"¦","bscr":"𝒷","Bscr":"ℬ","bsemi":"⁏","bsim":"∽","bsime":"⋍","bsolb":"⧅","bsol":"\\","bsolhsub":"⟈","bull":"•","bullet":"•","bump":"≎","bumpE":"⪮","bumpe":"≏","Bumpeq":"≎","bumpeq":"≏","Cacute":"Ć","cacute":"ć","capand":"⩄","capbrcup":"⩉","capcap":"⩋","cap":"∩","Cap":"⋒","capcup":"⩇","capdot":"⩀","CapitalDifferentialD":"ⅅ","caps":"∩︀","caret":"⁁","caron":"ˇ","Cayleys":"ℭ","ccaps":"⩍","Ccaron":"Č","ccaron":"č","Ccedil":"Ç","ccedil":"ç","Ccirc":"Ĉ","ccirc":"ĉ","Cconint":"∰","ccups":"⩌","ccupssm":"⩐","Cdot":"Ċ","cdot":"ċ","cedil":"¸","Cedilla":"¸","cemptyv":"⦲","cent":"¢","centerdot":"·","CenterDot":"·","cfr":"𝔠","Cfr":"ℭ","CHcy":"Ч","chcy":"ч","check":"✓","checkmark":"✓","Chi":"Χ","chi":"χ","circ":"ˆ","circeq":"≗","circlearrowleft":"↺","circlearrowright":"↻","circledast":"⊛","circledcirc":"⊚","circleddash":"⊝","CircleDot":"⊙","circledR":"®","circledS":"Ⓢ","CircleMinus":"⊖","CirclePlus":"⊕","CircleTimes":"⊗","cir":"○","cirE":"⧃","cire":"≗","cirfnint":"⨐","cirmid":"⫯","cirscir":"⧂","ClockwiseContourIntegral":"∲","CloseCurlyDoubleQuote":"”","CloseCurlyQuote":"’","clubs":"♣","clubsuit":"♣","colon":":","Colon":"∷","Colone":"⩴","colone":"≔","coloneq":"≔","comma":",","commat":"@","comp":"∁","compfn":"∘","complement":"∁","complexes":"ℂ","cong":"≅","congdot":"⩭","Congruent":"≡","conint":"∮","Conint":"∯","ContourIntegral":"∮","copf":"𝕔","Copf":"ℂ","coprod":"∐","Coproduct":"∐","copy":"©","COPY":"©","copysr":"℗","CounterClockwiseContourIntegral":"∳","crarr":"↵","cross":"✗","Cross":"⨯","Cscr":"𝒞","cscr":"𝒸","csub":"⫏","csube":"⫑","csup":"⫐","csupe":"⫒","ctdot":"⋯","cudarrl":"⤸","cudarrr":"⤵","cuepr":"⋞","cuesc":"⋟","cularr":"↶","cularrp":"⤽","cupbrcap":"⩈","cupcap":"⩆","CupCap":"≍","cup":"∪","Cup":"⋓","cupcup":"⩊","cupdot":"⊍","cupor":"⩅","cups":"∪︀","curarr":"↷","curarrm":"⤼","curlyeqprec":"⋞","curlyeqsucc":"⋟","curlyvee":"⋎","curlywedge":"⋏","curren":"¤","curvearrowleft":"↶","curvearrowright":"↷","cuvee":"⋎","cuwed":"⋏","cwconint":"∲","cwint":"∱","cylcty":"⌭","dagger":"†","Dagger":"‡","daleth":"ℸ","darr":"↓","Darr":"↡","dArr":"⇓","dash":"‐","Dashv":"⫤","dashv":"⊣","dbkarow":"⤏","dblac":"˝","Dcaron":"Ď","dcaron":"ď","Dcy":"Д","dcy":"д","ddagger":"‡","ddarr":"⇊","DD":"ⅅ","dd":"ⅆ","DDotrahd":"⤑","ddotseq":"⩷","deg":"°","Del":"∇","Delta":"Δ","delta":"δ","demptyv":"⦱","dfisht":"⥿","Dfr":"𝔇","dfr":"𝔡","dHar":"⥥","dharl":"⇃","dharr":"⇂","DiacriticalAcute":"´","DiacriticalDot":"˙","DiacriticalDoubleAcute":"˝","DiacriticalGrave":"`","DiacriticalTilde":"˜","diam":"⋄","diamond":"⋄","Diamond":"⋄","diamondsuit":"♦","diams":"♦","die":"¨","DifferentialD":"ⅆ","digamma":"ϝ","disin":"⋲","div":"÷","divide":"÷","divideontimes":"⋇","divonx":"⋇","DJcy":"Ђ","djcy":"ђ","dlcorn":"⌞","dlcrop":"⌍","dollar":"$","Dopf":"𝔻","dopf":"𝕕","Dot":"¨","dot":"˙","DotDot":"⃜","doteq":"≐","doteqdot":"≑","DotEqual":"≐","dotminus":"∸","dotplus":"∔","dotsquare":"⊡","doublebarwedge":"⌆","DoubleContourIntegral":"∯","DoubleDot":"¨","DoubleDownArrow":"⇓","DoubleLeftArrow":"⇐","DoubleLeftRightArrow":"⇔","DoubleLeftTee":"⫤","DoubleLongLeftArrow":"⟸","DoubleLongLeftRightArrow":"⟺","DoubleLongRightArrow":"⟹","DoubleRightArrow":"⇒","DoubleRightTee":"⊨","DoubleUpArrow":"⇑","DoubleUpDownArrow":"⇕","DoubleVerticalBar":"∥","DownArrowBar":"⤓","downarrow":"↓","DownArrow":"↓","Downarrow":"⇓","DownArrowUpArrow":"⇵","DownBreve":"̑","downdownarrows":"⇊","downharpoonleft":"⇃","downharpoonright":"⇂","DownLeftRightVector":"⥐","DownLeftTeeVector":"⥞","DownLeftVectorBar":"⥖","DownLeftVector":"↽","DownRightTeeVector":"⥟","DownRightVectorBar":"⥗","DownRightVector":"⇁","DownTeeArrow":"↧","DownTee":"⊤","drbkarow":"⤐","drcorn":"⌟","drcrop":"⌌","Dscr":"𝒟","dscr":"𝒹","DScy":"Ѕ","dscy":"ѕ","dsol":"⧶","Dstrok":"Đ","dstrok":"đ","dtdot":"⋱","dtri":"▿","dtrif":"▾","duarr":"⇵","duhar":"⥯","dwangle":"⦦","DZcy":"Џ","dzcy":"џ","dzigrarr":"⟿","Eacute":"É","eacute":"é","easter":"⩮","Ecaron":"Ě","ecaron":"ě","Ecirc":"Ê","ecirc":"ê","ecir":"≖","ecolon":"≕","Ecy":"Э","ecy":"э","eDDot":"⩷","Edot":"Ė","edot":"ė","eDot":"≑","ee":"ⅇ","efDot":"≒","Efr":"𝔈","efr":"𝔢","eg":"⪚","Egrave":"È","egrave":"è","egs":"⪖","egsdot":"⪘","el":"⪙","Element":"∈","elinters":"⏧","ell":"ℓ","els":"⪕","elsdot":"⪗","Emacr":"Ē","emacr":"ē","empty":"∅","emptyset":"∅","EmptySmallSquare":"◻","emptyv":"∅","EmptyVerySmallSquare":"▫","emsp13":" ","emsp14":" ","emsp":" ","ENG":"Ŋ","eng":"ŋ","ensp":" ","Eogon":"Ę","eogon":"ę","Eopf":"𝔼","eopf":"𝕖","epar":"⋕","eparsl":"⧣","eplus":"⩱","epsi":"ε","Epsilon":"Ε","epsilon":"ε","epsiv":"ϵ","eqcirc":"≖","eqcolon":"≕","eqsim":"≂","eqslantgtr":"⪖","eqslantless":"⪕","Equal":"⩵","equals":"=","EqualTilde":"≂","equest":"≟","Equilibrium":"⇌","equiv":"≡","equivDD":"⩸","eqvparsl":"⧥","erarr":"⥱","erDot":"≓","escr":"ℯ","Escr":"ℰ","esdot":"≐","Esim":"⩳","esim":"≂","Eta":"Η","eta":"η","ETH":"Ð","eth":"ð","Euml":"Ë","euml":"ë","euro":"€","excl":"!","exist":"∃","Exists":"∃","expectation":"ℰ","exponentiale":"ⅇ","ExponentialE":"ⅇ","fallingdotseq":"≒","Fcy":"Ф","fcy":"ф","female":"♀","ffilig":"ﬃ","fflig":"ﬀ","ffllig":"ﬄ","Ffr":"𝔉","ffr":"𝔣","filig":"ﬁ","FilledSmallSquare":"◼","FilledVerySmallSquare":"▪","fjlig":"fj","flat":"♭","fllig":"ﬂ","fltns":"▱","fnof":"ƒ","Fopf":"𝔽","fopf":"𝕗","forall":"∀","ForAll":"∀","fork":"⋔","forkv":"⫙","Fouriertrf":"ℱ","fpartint":"⨍","frac12":"½","frac13":"⅓","frac14":"¼","frac15":"⅕","frac16":"⅙","frac18":"⅛","frac23":"⅔","frac25":"⅖","frac34":"¾","frac35":"⅗","frac38":"⅜","frac45":"⅘","frac56":"⅚","frac58":"⅝","frac78":"⅞","frasl":"⁄","frown":"⌢","fscr":"𝒻","Fscr":"ℱ","gacute":"ǵ","Gamma":"Γ","gamma":"γ","Gammad":"Ϝ","gammad":"ϝ","gap":"⪆","Gbreve":"Ğ","gbreve":"ğ","Gcedil":"Ģ","Gcirc":"Ĝ","gcirc":"ĝ","Gcy":"Г","gcy":"г","Gdot":"Ġ","gdot":"ġ","ge":"≥","gE":"≧","gEl":"⪌","gel":"⋛","geq":"≥","geqq":"≧","geqslant":"⩾","gescc":"⪩","ges":"⩾","gesdot":"⪀","gesdoto":"⪂","gesdotol":"⪄","gesl":"⋛︀","gesles":"⪔","Gfr":"𝔊","gfr":"𝔤","gg":"≫","Gg":"⋙","ggg":"⋙","gimel":"ℷ","GJcy":"Ѓ","gjcy":"ѓ","gla":"⪥","gl":"≷","glE":"⪒","glj":"⪤","gnap":"⪊","gnapprox":"⪊","gne":"⪈","gnE":"≩","gneq":"⪈","gneqq":"≩","gnsim":"⋧","Gopf":"𝔾","gopf":"𝕘","grave":"`","GreaterEqual":"≥","GreaterEqualLess":"⋛","GreaterFullEqual":"≧","GreaterGreater":"⪢","GreaterLess":"≷","GreaterSlantEqual":"⩾","GreaterTilde":"≳","Gscr":"𝒢","gscr":"ℊ","gsim":"≳","gsime":"⪎","gsiml":"⪐","gtcc":"⪧","gtcir":"⩺","gt":">","GT":">","Gt":"≫","gtdot":"⋗","gtlPar":"⦕","gtquest":"⩼","gtrapprox":"⪆","gtrarr":"⥸","gtrdot":"⋗","gtreqless":"⋛","gtreqqless":"⪌","gtrless":"≷","gtrsim":"≳","gvertneqq":"≩︀","gvnE":"≩︀","Hacek":"ˇ","hairsp":" ","half":"½","hamilt":"ℋ","HARDcy":"Ъ","hardcy":"ъ","harrcir":"⥈","harr":"↔","hArr":"⇔","harrw":"↭","Hat":"^","hbar":"ℏ","Hcirc":"Ĥ","hcirc":"ĥ","hearts":"♥","heartsuit":"♥","hellip":"…","hercon":"⊹","hfr":"𝔥","Hfr":"ℌ","HilbertSpace":"ℋ","hksearow":"⤥","hkswarow":"⤦","hoarr":"⇿","homtht":"∻","hookleftarrow":"↩","hookrightarrow":"↪","hopf":"𝕙","Hopf":"ℍ","horbar":"―","HorizontalLine":"─","hscr":"𝒽","Hscr":"ℋ","hslash":"ℏ","Hstrok":"Ħ","hstrok":"ħ","HumpDownHump":"≎","HumpEqual":"≏","hybull":"⁃","hyphen":"‐","Iacute":"Í","iacute":"í","ic":"⁣","Icirc":"Î","icirc":"î","Icy":"И","icy":"и","Idot":"İ","IEcy":"Е","iecy":"е","iexcl":"¡","iff":"⇔","ifr":"𝔦","Ifr":"ℑ","Igrave":"Ì","igrave":"ì","ii":"ⅈ","iiiint":"⨌","iiint":"∭","iinfin":"⧜","iiota":"℩","IJlig":"Ĳ","ijlig":"ĳ","Imacr":"Ī","imacr":"ī","image":"ℑ","ImaginaryI":"ⅈ","imagline":"ℐ","imagpart":"ℑ","imath":"ı","Im":"ℑ","imof":"⊷","imped":"Ƶ","Implies":"⇒","incare":"℅","in":"∈","infin":"∞","infintie":"⧝","inodot":"ı","intcal":"⊺","int":"∫","Int":"∬","integers":"ℤ","Integral":"∫","intercal":"⊺","Intersection":"⋂","intlarhk":"⨗","intprod":"⨼","InvisibleComma":"⁣","InvisibleTimes":"⁢","IOcy":"Ё","iocy":"ё","Iogon":"Į","iogon":"į","Iopf":"𝕀","iopf":"𝕚","Iota":"Ι","iota":"ι","iprod":"⨼","iquest":"¿","iscr":"𝒾","Iscr":"ℐ","isin":"∈","isindot":"⋵","isinE":"⋹","isins":"⋴","isinsv":"⋳","isinv":"∈","it":"⁢","Itilde":"Ĩ","itilde":"ĩ","Iukcy":"І","iukcy":"і","Iuml":"Ï","iuml":"ï","Jcirc":"Ĵ","jcirc":"ĵ","Jcy":"Й","jcy":"й","Jfr":"𝔍","jfr":"𝔧","jmath":"ȷ","Jopf":"𝕁","jopf":"𝕛","Jscr":"𝒥","jscr":"𝒿","Jsercy":"Ј","jsercy":"ј","Jukcy":"Є","jukcy":"є","Kappa":"Κ","kappa":"κ","kappav":"ϰ","Kcedil":"Ķ","kcedil":"ķ","Kcy":"К","kcy":"к","Kfr":"𝔎","kfr":"𝔨","kgreen":"ĸ","KHcy":"Х","khcy":"х","KJcy":"Ќ","kjcy":"ќ","Kopf":"𝕂","kopf":"𝕜","Kscr":"𝒦","kscr":"𝓀","lAarr":"⇚","Lacute":"Ĺ","lacute":"ĺ","laemptyv":"⦴","lagran":"ℒ","Lambda":"Λ","lambda":"λ","lang":"⟨","Lang":"⟪","langd":"⦑","langle":"⟨","lap":"⪅","Laplacetrf":"ℒ","laquo":"«","larrb":"⇤","larrbfs":"⤟","larr":"←","Larr":"↞","lArr":"⇐","larrfs":"⤝","larrhk":"↩","larrlp":"↫","larrpl":"⤹","larrsim":"⥳","larrtl":"↢","latail":"⤙","lAtail":"⤛","lat":"⪫","late":"⪭","lates":"⪭︀","lbarr":"⤌","lBarr":"⤎","lbbrk":"❲","lbrace":"{","lbrack":"[","lbrke":"⦋","lbrksld":"⦏","lbrkslu":"⦍","Lcaron":"Ľ","lcaron":"ľ","Lcedil":"Ļ","lcedil":"ļ","lceil":"⌈","lcub":"{","Lcy":"Л","lcy":"л","ldca":"⤶","ldquo":"“","ldquor":"„","ldrdhar":"⥧","ldrushar":"⥋","ldsh":"↲","le":"≤","lE":"≦","LeftAngleBracket":"⟨","LeftArrowBar":"⇤","leftarrow":"←","LeftArrow":"←","Leftarrow":"⇐","LeftArrowRightArrow":"⇆","leftarrowtail":"↢","LeftCeiling":"⌈","LeftDoubleBracket":"⟦","LeftDownTeeVector":"⥡","LeftDownVectorBar":"⥙","LeftDownVector":"⇃","LeftFloor":"⌊","leftharpoondown":"↽","leftharpoonup":"↼","leftleftarrows":"⇇","leftrightarrow":"↔","LeftRightArrow":"↔","Leftrightarrow":"⇔","leftrightarrows":"⇆","leftrightharpoons":"⇋","leftrightsquigarrow":"↭","LeftRightVector":"⥎","LeftTeeArrow":"↤","LeftTee":"⊣","LeftTeeVector":"⥚","leftthreetimes":"⋋","LeftTriangleBar":"⧏","LeftTriangle":"⊲","LeftTriangleEqual":"⊴","LeftUpDownVector":"⥑","LeftUpTeeVector":"⥠","LeftUpVectorBar":"⥘","LeftUpVector":"↿","LeftVectorBar":"⥒","LeftVector":"↼","lEg":"⪋","leg":"⋚","leq":"≤","leqq":"≦","leqslant":"⩽","lescc":"⪨","les":"⩽","lesdot":"⩿","lesdoto":"⪁","lesdotor":"⪃","lesg":"⋚︀","lesges":"⪓","lessapprox":"⪅","lessdot":"⋖","lesseqgtr":"⋚","lesseqqgtr":"⪋","LessEqualGreater":"⋚","LessFullEqual":"≦","LessGreater":"≶","lessgtr":"≶","LessLess":"⪡","lesssim":"≲","LessSlantEqual":"⩽","LessTilde":"≲","lfisht":"⥼","lfloor":"⌊","Lfr":"𝔏","lfr":"𝔩","lg":"≶","lgE":"⪑","lHar":"⥢","lhard":"↽","lharu":"↼","lharul":"⥪","lhblk":"▄","LJcy":"Љ","ljcy":"љ","llarr":"⇇","ll":"≪","Ll":"⋘","llcorner":"⌞","Lleftarrow":"⇚","llhard":"⥫","lltri":"◺","Lmidot":"Ŀ","lmidot":"ŀ","lmoustache":"⎰","lmoust":"⎰","lnap":"⪉","lnapprox":"⪉","lne":"⪇","lnE":"≨","lneq":"⪇","lneqq":"≨","lnsim":"⋦","loang":"⟬","loarr":"⇽","lobrk":"⟦","longleftarrow":"⟵","LongLeftArrow":"⟵","Longleftarrow":"⟸","longleftrightarrow":"⟷","LongLeftRightArrow":"⟷","Longleftrightarrow":"⟺","longmapsto":"⟼","longrightarrow":"⟶","LongRightArrow":"⟶","Longrightarrow":"⟹","looparrowleft":"↫","looparrowright":"↬","lopar":"⦅","Lopf":"𝕃","lopf":"𝕝","loplus":"⨭","lotimes":"⨴","lowast":"∗","lowbar":"_","LowerLeftArrow":"↙","LowerRightArrow":"↘","loz":"◊","lozenge":"◊","lozf":"⧫","lpar":"(","lparlt":"⦓","lrarr":"⇆","lrcorner":"⌟","lrhar":"⇋","lrhard":"⥭","lrm":"‎","lrtri":"⊿","lsaquo":"‹","lscr":"𝓁","Lscr":"ℒ","lsh":"↰","Lsh":"↰","lsim":"≲","lsime":"⪍","lsimg":"⪏","lsqb":"[","lsquo":"‘","lsquor":"‚","Lstrok":"Ł","lstrok":"ł","ltcc":"⪦","ltcir":"⩹","lt":"<","LT":"<","Lt":"≪","ltdot":"⋖","lthree":"⋋","ltimes":"⋉","ltlarr":"⥶","ltquest":"⩻","ltri":"◃","ltrie":"⊴","ltrif":"◂","ltrPar":"⦖","lurdshar":"⥊","luruhar":"⥦","lvertneqq":"≨︀","lvnE":"≨︀","macr":"¯","male":"♂","malt":"✠","maltese":"✠","Map":"⤅","map":"↦","mapsto":"↦","mapstodown":"↧","mapstoleft":"↤","mapstoup":"↥","marker":"▮","mcomma":"⨩","Mcy":"М","mcy":"м","mdash":"—","mDDot":"∺","measuredangle":"∡","MediumSpace":" ","Mellintrf":"ℳ","Mfr":"𝔐","mfr":"𝔪","mho":"℧","micro":"µ","midast":"*","midcir":"⫰","mid":"∣","middot":"·","minusb":"⊟","minus":"−","minusd":"∸","minusdu":"⨪","MinusPlus":"∓","mlcp":"⫛","mldr":"…","mnplus":"∓","models":"⊧","Mopf":"𝕄","mopf":"𝕞","mp":"∓","mscr":"𝓂","Mscr":"ℳ","mstpos":"∾","Mu":"Μ","mu":"μ","multimap":"⊸","mumap":"⊸","nabla":"∇","Nacute":"Ń","nacute":"ń","nang":"∠⃒","nap":"≉","napE":"⩰̸","napid":"≋̸","napos":"ŉ","napprox":"≉","natural":"♮","naturals":"ℕ","natur":"♮","nbsp":" ","nbump":"≎̸","nbumpe":"≏̸","ncap":"⩃","Ncaron":"Ň","ncaron":"ň","Ncedil":"Ņ","ncedil":"ņ","ncong":"≇","ncongdot":"⩭̸","ncup":"⩂","Ncy":"Н","ncy":"н","ndash":"–","nearhk":"⤤","nearr":"↗","neArr":"⇗","nearrow":"↗","ne":"≠","nedot":"≐̸","NegativeMediumSpace":"​","NegativeThickSpace":"​","NegativeThinSpace":"​","NegativeVeryThinSpace":"​","nequiv":"≢","nesear":"⤨","nesim":"≂̸","NestedGreaterGreater":"≫","NestedLessLess":"≪","NewLine":"\n","nexist":"∄","nexists":"∄","Nfr":"𝔑","nfr":"𝔫","ngE":"≧̸","nge":"≱","ngeq":"≱","ngeqq":"≧̸","ngeqslant":"⩾̸","nges":"⩾̸","nGg":"⋙̸","ngsim":"≵","nGt":"≫⃒","ngt":"≯","ngtr":"≯","nGtv":"≫̸","nharr":"↮","nhArr":"⇎","nhpar":"⫲","ni":"∋","nis":"⋼","nisd":"⋺","niv":"∋","NJcy":"Њ","njcy":"њ","nlarr":"↚","nlArr":"⇍","nldr":"‥","nlE":"≦̸","nle":"≰","nleftarrow":"↚","nLeftarrow":"⇍","nleftrightarrow":"↮","nLeftrightarrow":"⇎","nleq":"≰","nleqq":"≦̸","nleqslant":"⩽̸","nles":"⩽̸","nless":"≮","nLl":"⋘̸","nlsim":"≴","nLt":"≪⃒","nlt":"≮","nltri":"⋪","nltrie":"⋬","nLtv":"≪̸","nmid":"∤","NoBreak":"⁠","NonBreakingSpace":" ","nopf":"𝕟","Nopf":"ℕ","Not":"⫬","not":"¬","NotCongruent":"≢","NotCupCap":"≭","NotDoubleVerticalBar":"∦","NotElement":"∉","NotEqual":"≠","NotEqualTilde":"≂̸","NotExists":"∄","NotGreater":"≯","NotGreaterEqual":"≱","NotGreaterFullEqual":"≧̸","NotGreaterGreater":"≫̸","NotGreaterLess":"≹","NotGreaterSlantEqual":"⩾̸","NotGreaterTilde":"≵","NotHumpDownHump":"≎̸","NotHumpEqual":"≏̸","notin":"∉","notindot":"⋵̸","notinE":"⋹̸","notinva":"∉","notinvb":"⋷","notinvc":"⋶","NotLeftTriangleBar":"⧏̸","NotLeftTriangle":"⋪","NotLeftTriangleEqual":"⋬","NotLess":"≮","NotLessEqual":"≰","NotLessGreater":"≸","NotLessLess":"≪̸","NotLessSlantEqual":"⩽̸","NotLessTilde":"≴","NotNestedGreaterGreater":"⪢̸","NotNestedLessLess":"⪡̸","notni":"∌","notniva":"∌","notnivb":"⋾","notnivc":"⋽","NotPrecedes":"⊀","NotPrecedesEqual":"⪯̸","NotPrecedesSlantEqual":"⋠","NotReverseElement":"∌","NotRightTriangleBar":"⧐̸","NotRightTriangle":"⋫","NotRightTriangleEqual":"⋭","NotSquareSubset":"⊏̸","NotSquareSubsetEqual":"⋢","NotSquareSuperset":"⊐̸","NotSquareSupersetEqual":"⋣","NotSubset":"⊂⃒","NotSubsetEqual":"⊈","NotSucceeds":"⊁","NotSucceedsEqual":"⪰̸","NotSucceedsSlantEqual":"⋡","NotSucceedsTilde":"≿̸","NotSuperset":"⊃⃒","NotSupersetEqual":"⊉","NotTilde":"≁","NotTildeEqual":"≄","NotTildeFullEqual":"≇","NotTildeTilde":"≉","NotVerticalBar":"∤","nparallel":"∦","npar":"∦","nparsl":"⫽⃥","npart":"∂̸","npolint":"⨔","npr":"⊀","nprcue":"⋠","nprec":"⊀","npreceq":"⪯̸","npre":"⪯̸","nrarrc":"⤳̸","nrarr":"↛","nrArr":"⇏","nrarrw":"↝̸","nrightarrow":"↛","nRightarrow":"⇏","nrtri":"⋫","nrtrie":"⋭","nsc":"⊁","nsccue":"⋡","nsce":"⪰̸","Nscr":"𝒩","nscr":"𝓃","nshortmid":"∤","nshortparallel":"∦","nsim":"≁","nsime":"≄","nsimeq":"≄","nsmid":"∤","nspar":"∦","nsqsube":"⋢","nsqsupe":"⋣","nsub":"⊄","nsubE":"⫅̸","nsube":"⊈","nsubset":"⊂⃒","nsubseteq":"⊈","nsubseteqq":"⫅̸","nsucc":"⊁","nsucceq":"⪰̸","nsup":"⊅","nsupE":"⫆̸","nsupe":"⊉","nsupset":"⊃⃒","nsupseteq":"⊉","nsupseteqq":"⫆̸","ntgl":"≹","Ntilde":"Ñ","ntilde":"ñ","ntlg":"≸","ntriangleleft":"⋪","ntrianglelefteq":"⋬","ntriangleright":"⋫","ntrianglerighteq":"⋭","Nu":"Ν","nu":"ν","num":"#","numero":"№","numsp":" ","nvap":"≍⃒","nvdash":"⊬","nvDash":"⊭","nVdash":"⊮","nVDash":"⊯","nvge":"≥⃒","nvgt":">⃒","nvHarr":"⤄","nvinfin":"⧞","nvlArr":"⤂","nvle":"≤⃒","nvlt":"<⃒","nvltrie":"⊴⃒","nvrArr":"⤃","nvrtrie":"⊵⃒","nvsim":"∼⃒","nwarhk":"⤣","nwarr":"↖","nwArr":"⇖","nwarrow":"↖","nwnear":"⤧","Oacute":"Ó","oacute":"ó","oast":"⊛","Ocirc":"Ô","ocirc":"ô","ocir":"⊚","Ocy":"О","ocy":"о","odash":"⊝","Odblac":"Ő","odblac":"ő","odiv":"⨸","odot":"⊙","odsold":"⦼","OElig":"Œ","oelig":"œ","ofcir":"⦿","Ofr":"𝔒","ofr":"𝔬","ogon":"˛","Ograve":"Ò","ograve":"ò","ogt":"⧁","ohbar":"⦵","ohm":"Ω","oint":"∮","olarr":"↺","olcir":"⦾","olcross":"⦻","oline":"‾","olt":"⧀","Omacr":"Ō","omacr":"ō","Omega":"Ω","omega":"ω","Omicron":"Ο","omicron":"ο","omid":"⦶","ominus":"⊖","Oopf":"𝕆","oopf":"𝕠","opar":"⦷","OpenCurlyDoubleQuote":"“","OpenCurlyQuote":"‘","operp":"⦹","oplus":"⊕","orarr":"↻","Or":"⩔","or":"∨","ord":"⩝","order":"ℴ","orderof":"ℴ","ordf":"ª","ordm":"º","origof":"⊶","oror":"⩖","orslope":"⩗","orv":"⩛","oS":"Ⓢ","Oscr":"𝒪","oscr":"ℴ","Oslash":"Ø","oslash":"ø","osol":"⊘","Otilde":"Õ","otilde":"õ","otimesas":"⨶","Otimes":"⨷","otimes":"⊗","Ouml":"Ö","ouml":"ö","ovbar":"⌽","OverBar":"‾","OverBrace":"⏞","OverBracket":"⎴","OverParenthesis":"⏜","para":"¶","parallel":"∥","par":"∥","parsim":"⫳","parsl":"⫽","part":"∂","PartialD":"∂","Pcy":"П","pcy":"п","percnt":"%","period":".","permil":"‰","perp":"⊥","pertenk":"‱","Pfr":"𝔓","pfr":"𝔭","Phi":"Φ","phi":"φ","phiv":"ϕ","phmmat":"ℳ","phone":"☎","Pi":"Π","pi":"π","pitchfork":"⋔","piv":"ϖ","planck":"ℏ","planckh":"ℎ","plankv":"ℏ","plusacir":"⨣","plusb":"⊞","pluscir":"⨢","plus":"+","plusdo":"∔","plusdu":"⨥","pluse":"⩲","PlusMinus":"±","plusmn":"±","plussim":"⨦","plustwo":"⨧","pm":"±","Poincareplane":"ℌ","pointint":"⨕","popf":"𝕡","Popf":"ℙ","pound":"£","prap":"⪷","Pr":"⪻","pr":"≺","prcue":"≼","precapprox":"⪷","prec":"≺","preccurlyeq":"≼","Precedes":"≺","PrecedesEqual":"⪯","PrecedesSlantEqual":"≼","PrecedesTilde":"≾","preceq":"⪯","precnapprox":"⪹","precneqq":"⪵","precnsim":"⋨","pre":"⪯","prE":"⪳","precsim":"≾","prime":"′","Prime":"″","primes":"ℙ","prnap":"⪹","prnE":"⪵","prnsim":"⋨","prod":"∏","Product":"∏","profalar":"⌮","profline":"⌒","profsurf":"⌓","prop":"∝","Proportional":"∝","Proportion":"∷","propto":"∝","prsim":"≾","prurel":"⊰","Pscr":"𝒫","pscr":"𝓅","Psi":"Ψ","psi":"ψ","puncsp":" ","Qfr":"𝔔","qfr":"𝔮","qint":"⨌","qopf":"𝕢","Qopf":"ℚ","qprime":"⁗","Qscr":"𝒬","qscr":"𝓆","quaternions":"ℍ","quatint":"⨖","quest":"?","questeq":"≟","quot":"\"","QUOT":"\"","rAarr":"⇛","race":"∽̱","Racute":"Ŕ","racute":"ŕ","radic":"√","raemptyv":"⦳","rang":"⟩","Rang":"⟫","rangd":"⦒","range":"⦥","rangle":"⟩","raquo":"»","rarrap":"⥵","rarrb":"⇥","rarrbfs":"⤠","rarrc":"⤳","rarr":"→","Rarr":"↠","rArr":"⇒","rarrfs":"⤞","rarrhk":"↪","rarrlp":"↬","rarrpl":"⥅","rarrsim":"⥴","Rarrtl":"⤖","rarrtl":"↣","rarrw":"↝","ratail":"⤚","rAtail":"⤜","ratio":"∶","rationals":"ℚ","rbarr":"⤍","rBarr":"⤏","RBarr":"⤐","rbbrk":"❳","rbrace":"}","rbrack":"]","rbrke":"⦌","rbrksld":"⦎","rbrkslu":"⦐","Rcaron":"Ř","rcaron":"ř","Rcedil":"Ŗ","rcedil":"ŗ","rceil":"⌉","rcub":"}","Rcy":"Р","rcy":"р","rdca":"⤷","rdldhar":"⥩","rdquo":"”","rdquor":"”","rdsh":"↳","real":"ℜ","realine":"ℛ","realpart":"ℜ","reals":"ℝ","Re":"ℜ","rect":"▭","reg":"®","REG":"®","ReverseElement":"∋","ReverseEquilibrium":"⇋","ReverseUpEquilibrium":"⥯","rfisht":"⥽","rfloor":"⌋","rfr":"𝔯","Rfr":"ℜ","rHar":"⥤","rhard":"⇁","rharu":"⇀","rharul":"⥬","Rho":"Ρ","rho":"ρ","rhov":"ϱ","RightAngleBracket":"⟩","RightArrowBar":"⇥","rightarrow":"→","RightArrow":"→","Rightarrow":"⇒","RightArrowLeftArrow":"⇄","rightarrowtail":"↣","RightCeiling":"⌉","RightDoubleBracket":"⟧","RightDownTeeVector":"⥝","RightDownVectorBar":"⥕","RightDownVector":"⇂","RightFloor":"⌋","rightharpoondown":"⇁","rightharpoonup":"⇀","rightleftarrows":"⇄","rightleftharpoons":"⇌","rightrightarrows":"⇉","rightsquigarrow":"↝","RightTeeArrow":"↦","RightTee":"⊢","RightTeeVector":"⥛","rightthreetimes":"⋌","RightTriangleBar":"⧐","RightTriangle":"⊳","RightTriangleEqual":"⊵","RightUpDownVector":"⥏","RightUpTeeVector":"⥜","RightUpVectorBar":"⥔","RightUpVector":"↾","RightVectorBar":"⥓","RightVector":"⇀","ring":"˚","risingdotseq":"≓","rlarr":"⇄","rlhar":"⇌","rlm":"‏","rmoustache":"⎱","rmoust":"⎱","rnmid":"⫮","roang":"⟭","roarr":"⇾","robrk":"⟧","ropar":"⦆","ropf":"𝕣","Ropf":"ℝ","roplus":"⨮","rotimes":"⨵","RoundImplies":"⥰","rpar":")","rpargt":"⦔","rppolint":"⨒","rrarr":"⇉","Rrightarrow":"⇛","rsaquo":"›","rscr":"𝓇","Rscr":"ℛ","rsh":"↱","Rsh":"↱","rsqb":"]","rsquo":"’","rsquor":"’","rthree":"⋌","rtimes":"⋊","rtri":"▹","rtrie":"⊵","rtrif":"▸","rtriltri":"⧎","RuleDelayed":"⧴","ruluhar":"⥨","rx":"℞","Sacute":"Ś","sacute":"ś","sbquo":"‚","scap":"⪸","Scaron":"Š","scaron":"š","Sc":"⪼","sc":"≻","sccue":"≽","sce":"⪰","scE":"⪴","Scedil":"Ş","scedil":"ş","Scirc":"Ŝ","scirc":"ŝ","scnap":"⪺","scnE":"⪶","scnsim":"⋩","scpolint":"⨓","scsim":"≿","Scy":"С","scy":"с","sdotb":"⊡","sdot":"⋅","sdote":"⩦","searhk":"⤥","searr":"↘","seArr":"⇘","searrow":"↘","sect":"§","semi":";","seswar":"⤩","setminus":"∖","setmn":"∖","sext":"✶","Sfr":"𝔖","sfr":"𝔰","sfrown":"⌢","sharp":"♯","SHCHcy":"Щ","shchcy":"щ","SHcy":"Ш","shcy":"ш","ShortDownArrow":"↓","ShortLeftArrow":"←","shortmid":"∣","shortparallel":"∥","ShortRightArrow":"→","ShortUpArrow":"↑","shy":"­","Sigma":"Σ","sigma":"σ","sigmaf":"ς","sigmav":"ς","sim":"∼","simdot":"⩪","sime":"≃","simeq":"≃","simg":"⪞","simgE":"⪠","siml":"⪝","simlE":"⪟","simne":"≆","simplus":"⨤","simrarr":"⥲","slarr":"←","SmallCircle":"∘","smallsetminus":"∖","smashp":"⨳","smeparsl":"⧤","smid":"∣","smile":"⌣","smt":"⪪","smte":"⪬","smtes":"⪬︀","SOFTcy":"Ь","softcy":"ь","solbar":"⌿","solb":"⧄","sol":"/","Sopf":"𝕊","sopf":"𝕤","spades":"♠","spadesuit":"♠","spar":"∥","sqcap":"⊓","sqcaps":"⊓︀","sqcup":"⊔","sqcups":"⊔︀","Sqrt":"√","sqsub":"⊏","sqsube":"⊑","sqsubset":"⊏","sqsubseteq":"⊑","sqsup":"⊐","sqsupe":"⊒","sqsupset":"⊐","sqsupseteq":"⊒","square":"□","Square":"□","SquareIntersection":"⊓","SquareSubset":"⊏","SquareSubsetEqual":"⊑","SquareSuperset":"⊐","SquareSupersetEqual":"⊒","SquareUnion":"⊔","squarf":"▪","squ":"□","squf":"▪","srarr":"→","Sscr":"𝒮","sscr":"𝓈","ssetmn":"∖","ssmile":"⌣","sstarf":"⋆","Star":"⋆","star":"☆","starf":"★","straightepsilon":"ϵ","straightphi":"ϕ","strns":"¯","sub":"⊂","Sub":"⋐","subdot":"⪽","subE":"⫅","sube":"⊆","subedot":"⫃","submult":"⫁","subnE":"⫋","subne":"⊊","subplus":"⪿","subrarr":"⥹","subset":"⊂","Subset":"⋐","subseteq":"⊆","subseteqq":"⫅","SubsetEqual":"⊆","subsetneq":"⊊","subsetneqq":"⫋","subsim":"⫇","subsub":"⫕","subsup":"⫓","succapprox":"⪸","succ":"≻","succcurlyeq":"≽","Succeeds":"≻","SucceedsEqual":"⪰","SucceedsSlantEqual":"≽","SucceedsTilde":"≿","succeq":"⪰","succnapprox":"⪺","succneqq":"⪶","succnsim":"⋩","succsim":"≿","SuchThat":"∋","sum":"∑","Sum":"∑","sung":"♪","sup1":"¹","sup2":"²","sup3":"³","sup":"⊃","Sup":"⋑","supdot":"⪾","supdsub":"⫘","supE":"⫆","supe":"⊇","supedot":"⫄","Superset":"⊃","SupersetEqual":"⊇","suphsol":"⟉","suphsub":"⫗","suplarr":"⥻","supmult":"⫂","supnE":"⫌","supne":"⊋","supplus":"⫀","supset":"⊃","Supset":"⋑","supseteq":"⊇","supseteqq":"⫆","supsetneq":"⊋","supsetneqq":"⫌","supsim":"⫈","supsub":"⫔","supsup":"⫖","swarhk":"⤦","swarr":"↙","swArr":"⇙","swarrow":"↙","swnwar":"⤪","szlig":"ß","Tab":"\t","target":"⌖","Tau":"Τ","tau":"τ","tbrk":"⎴","Tcaron":"Ť","tcaron":"ť","Tcedil":"Ţ","tcedil":"ţ","Tcy":"Т","tcy":"т","tdot":"⃛","telrec":"⌕","Tfr":"𝔗","tfr":"𝔱","there4":"∴","therefore":"∴","Therefore":"∴","Theta":"Θ","theta":"θ","thetasym":"ϑ","thetav":"ϑ","thickapprox":"≈","thicksim":"∼","ThickSpace":"  ","ThinSpace":" ","thinsp":" ","thkap":"≈","thksim":"∼","THORN":"Þ","thorn":"þ","tilde":"˜","Tilde":"∼","TildeEqual":"≃","TildeFullEqual":"≅","TildeTilde":"≈","timesbar":"⨱","timesb":"⊠","times":"×","timesd":"⨰","tint":"∭","toea":"⤨","topbot":"⌶","topcir":"⫱","top":"⊤","Topf":"𝕋","topf":"𝕥","topfork":"⫚","tosa":"⤩","tprime":"‴","trade":"™","TRADE":"™","triangle":"▵","triangledown":"▿","triangleleft":"◃","trianglelefteq":"⊴","triangleq":"≜","triangleright":"▹","trianglerighteq":"⊵","tridot":"◬","trie":"≜","triminus":"⨺","TripleDot":"⃛","triplus":"⨹","trisb":"⧍","tritime":"⨻","trpezium":"⏢","Tscr":"𝒯","tscr":"𝓉","TScy":"Ц","tscy":"ц","TSHcy":"Ћ","tshcy":"ћ","Tstrok":"Ŧ","tstrok":"ŧ","twixt":"≬","twoheadleftarrow":"↞","twoheadrightarrow":"↠","Uacute":"Ú","uacute":"ú","uarr":"↑","Uarr":"↟","uArr":"⇑","Uarrocir":"⥉","Ubrcy":"Ў","ubrcy":"ў","Ubreve":"Ŭ","ubreve":"ŭ","Ucirc":"Û","ucirc":"û","Ucy":"У","ucy":"у","udarr":"⇅","Udblac":"Ű","udblac":"ű","udhar":"⥮","ufisht":"⥾","Ufr":"𝔘","ufr":"𝔲","Ugrave":"Ù","ugrave":"ù","uHar":"⥣","uharl":"↿","uharr":"↾","uhblk":"▀","ulcorn":"⌜","ulcorner":"⌜","ulcrop":"⌏","ultri":"◸","Umacr":"Ū","umacr":"ū","uml":"¨","UnderBar":"_","UnderBrace":"⏟","UnderBracket":"⎵","UnderParenthesis":"⏝","Union":"⋃","UnionPlus":"⊎","Uogon":"Ų","uogon":"ų","Uopf":"𝕌","uopf":"𝕦","UpArrowBar":"⤒","uparrow":"↑","UpArrow":"↑","Uparrow":"⇑","UpArrowDownArrow":"⇅","updownarrow":"↕","UpDownArrow":"↕","Updownarrow":"⇕","UpEquilibrium":"⥮","upharpoonleft":"↿","upharpoonright":"↾","uplus":"⊎","UpperLeftArrow":"↖","UpperRightArrow":"↗","upsi":"υ","Upsi":"ϒ","upsih":"ϒ","Upsilon":"Υ","upsilon":"υ","UpTeeArrow":"↥","UpTee":"⊥","upuparrows":"⇈","urcorn":"⌝","urcorner":"⌝","urcrop":"⌎","Uring":"Ů","uring":"ů","urtri":"◹","Uscr":"𝒰","uscr":"𝓊","utdot":"⋰","Utilde":"Ũ","utilde":"ũ","utri":"▵","utrif":"▴","uuarr":"⇈","Uuml":"Ü","uuml":"ü","uwangle":"⦧","vangrt":"⦜","varepsilon":"ϵ","varkappa":"ϰ","varnothing":"∅","varphi":"ϕ","varpi":"ϖ","varpropto":"∝","varr":"↕","vArr":"⇕","varrho":"ϱ","varsigma":"ς","varsubsetneq":"⊊︀","varsubsetneqq":"⫋︀","varsupsetneq":"⊋︀","varsupsetneqq":"⫌︀","vartheta":"ϑ","vartriangleleft":"⊲","vartriangleright":"⊳","vBar":"⫨","Vbar":"⫫","vBarv":"⫩","Vcy":"В","vcy":"в","vdash":"⊢","vDash":"⊨","Vdash":"⊩","VDash":"⊫","Vdashl":"⫦","veebar":"⊻","vee":"∨","Vee":"⋁","veeeq":"≚","vellip":"⋮","verbar":"|","Verbar":"‖","vert":"|","Vert":"‖","VerticalBar":"∣","VerticalLine":"|","VerticalSeparator":"❘","VerticalTilde":"≀","VeryThinSpace":" ","Vfr":"𝔙","vfr":"𝔳","vltri":"⊲","vnsub":"⊂⃒","vnsup":"⊃⃒","Vopf":"𝕍","vopf":"𝕧","vprop":"∝","vrtri":"⊳","Vscr":"𝒱","vscr":"𝓋","vsubnE":"⫋︀","vsubne":"⊊︀","vsupnE":"⫌︀","vsupne":"⊋︀","Vvdash":"⊪","vzigzag":"⦚","Wcirc":"Ŵ","wcirc":"ŵ","wedbar":"⩟","wedge":"∧","Wedge":"⋀","wedgeq":"≙","weierp":"℘","Wfr":"𝔚","wfr":"𝔴","Wopf":"𝕎","wopf":"𝕨","wp":"℘","wr":"≀","wreath":"≀","Wscr":"𝒲","wscr":"𝓌","xcap":"⋂","xcirc":"◯","xcup":"⋃","xdtri":"▽","Xfr":"𝔛","xfr":"𝔵","xharr":"⟷","xhArr":"⟺","Xi":"Ξ","xi":"ξ","xlarr":"⟵","xlArr":"⟸","xmap":"⟼","xnis":"⋻","xodot":"⨀","Xopf":"𝕏","xopf":"𝕩","xoplus":"⨁","xotime":"⨂","xrarr":"⟶","xrArr":"⟹","Xscr":"𝒳","xscr":"𝓍","xsqcup":"⨆","xuplus":"⨄","xutri":"△","xvee":"⋁","xwedge":"⋀","Yacute":"Ý","yacute":"ý","YAcy":"Я","yacy":"я","Ycirc":"Ŷ","ycirc":"ŷ","Ycy":"Ы","ycy":"ы","yen":"¥","Yfr":"𝔜","yfr":"𝔶","YIcy":"Ї","yicy":"ї","Yopf":"𝕐","yopf":"𝕪","Yscr":"𝒴","yscr":"𝓎","YUcy":"Ю","yucy":"ю","yuml":"ÿ","Yuml":"Ÿ","Zacute":"Ź","zacute":"ź","Zcaron":"Ž","zcaron":"ž","Zcy":"З","zcy":"з","Zdot":"Ż","zdot":"ż","zeetrf":"ℨ","ZeroWidthSpace":"​","Zeta":"Ζ","zeta":"ζ","zfr":"𝔷","Zfr":"ℨ","ZHcy":"Ж","zhcy":"ж","zigrarr":"⇝","zopf":"𝕫","Zopf":"ℤ","Zscr":"𝒵","zscr":"𝓏","zwj":"‍","zwnj":"‌"}
 
 /***/ }),
-/* 60 */
+/* 64 */
 /***/ (function(module, exports) {
 
 	module.exports=/[!-#%-\*,-/:;\?@\[-\]_\{\}\xA1\xA7\xAB\xB6\xB7\xBB\xBF\u037E\u0387\u055A-\u055F\u0589\u058A\u05BE\u05C0\u05C3\u05C6\u05F3\u05F4\u0609\u060A\u060C\u060D\u061B\u061E\u061F\u066A-\u066D\u06D4\u0700-\u070D\u07F7-\u07F9\u0830-\u083E\u085E\u0964\u0965\u0970\u0AF0\u0DF4\u0E4F\u0E5A\u0E5B\u0F04-\u0F12\u0F14\u0F3A-\u0F3D\u0F85\u0FD0-\u0FD4\u0FD9\u0FDA\u104A-\u104F\u10FB\u1360-\u1368\u1400\u166D\u166E\u169B\u169C\u16EB-\u16ED\u1735\u1736\u17D4-\u17D6\u17D8-\u17DA\u1800-\u180A\u1944\u1945\u1A1E\u1A1F\u1AA0-\u1AA6\u1AA8-\u1AAD\u1B5A-\u1B60\u1BFC-\u1BFF\u1C3B-\u1C3F\u1C7E\u1C7F\u1CC0-\u1CC7\u1CD3\u2010-\u2027\u2030-\u2043\u2045-\u2051\u2053-\u205E\u207D\u207E\u208D\u208E\u2308-\u230B\u2329\u232A\u2768-\u2775\u27C5\u27C6\u27E6-\u27EF\u2983-\u2998\u29D8-\u29DB\u29FC\u29FD\u2CF9-\u2CFC\u2CFE\u2CFF\u2D70\u2E00-\u2E2E\u2E30-\u2E44\u3001-\u3003\u3008-\u3011\u3014-\u301F\u3030\u303D\u30A0\u30FB\uA4FE\uA4FF\uA60D-\uA60F\uA673\uA67E\uA6F2-\uA6F7\uA874-\uA877\uA8CE\uA8CF\uA8F8-\uA8FA\uA8FC\uA92E\uA92F\uA95F\uA9C1-\uA9CD\uA9DE\uA9DF\uAA5C-\uAA5F\uAADE\uAADF\uAAF0\uAAF1\uABEB\uFD3E\uFD3F\uFE10-\uFE19\uFE30-\uFE52\uFE54-\uFE61\uFE63\uFE68\uFE6A\uFE6B\uFF01-\uFF03\uFF05-\uFF0A\uFF0C-\uFF0F\uFF1A\uFF1B\uFF1F\uFF20\uFF3B-\uFF3D\uFF3F\uFF5B\uFF5D\uFF5F-\uFF65]|\uD800[\uDD00-\uDD02\uDF9F\uDFD0]|\uD801\uDD6F|\uD802[\uDC57\uDD1F\uDD3F\uDE50-\uDE58\uDE7F\uDEF0-\uDEF6\uDF39-\uDF3F\uDF99-\uDF9C]|\uD804[\uDC47-\uDC4D\uDCBB\uDCBC\uDCBE-\uDCC1\uDD40-\uDD43\uDD74\uDD75\uDDC5-\uDDC9\uDDCD\uDDDB\uDDDD-\uDDDF\uDE38-\uDE3D\uDEA9]|\uD805[\uDC4B-\uDC4F\uDC5B\uDC5D\uDCC6\uDDC1-\uDDD7\uDE41-\uDE43\uDE60-\uDE6C\uDF3C-\uDF3E]|\uD807[\uDC41-\uDC45\uDC70\uDC71]|\uD809[\uDC70-\uDC74]|\uD81A[\uDE6E\uDE6F\uDEF5\uDF37-\uDF3B\uDF44]|\uD82F\uDC9F|\uD836[\uDE87-\uDE8B]|\uD83A[\uDD5E\uDD5F]/
 
 /***/ }),
-/* 61 */
+/* 65 */
 /***/ (function(module, exports, __webpack_require__) {
 
 	'use strict';
 
 
-	module.exports.encode = __webpack_require__(62);
-	module.exports.decode = __webpack_require__(63);
-	module.exports.format = __webpack_require__(64);
-	module.exports.parse  = __webpack_require__(65);
+	module.exports.encode = __webpack_require__(66);
+	module.exports.decode = __webpack_require__(67);
+	module.exports.format = __webpack_require__(68);
+	module.exports.parse  = __webpack_require__(69);
 
 
 /***/ }),
-/* 62 */
+/* 66 */
 /***/ (function(module, exports) {
 
 	
@@ -2249,7 +2292,7 @@ return /******/ (function(modules) { // webpackBootstrap
 
 
 /***/ }),
-/* 63 */
+/* 67 */
 /***/ (function(module, exports) {
 
 	
@@ -2377,7 +2420,7 @@ return /******/ (function(modules) { // webpackBootstrap
 
 
 /***/ }),
-/* 64 */
+/* 68 */
 /***/ (function(module, exports) {
 
 	
@@ -2408,7 +2451,7 @@ return /******/ (function(modules) { // webpackBootstrap
 
 
 /***/ }),
-/* 65 */
+/* 69 */
 /***/ (function(module, exports) {
 
 	// Copyright Joyent, Inc. and other Node contributors.
@@ -2726,57 +2769,57 @@ return /******/ (function(modules) { // webpackBootstrap
 
 
 /***/ }),
-/* 66 */
+/* 70 */
 /***/ (function(module, exports, __webpack_require__) {
 
 	'use strict';
 
-	exports.Any = __webpack_require__(67);
-	exports.Cc  = __webpack_require__(68);
-	exports.Cf  = __webpack_require__(69);
-	exports.P   = __webpack_require__(60);
-	exports.Z   = __webpack_require__(70);
+	exports.Any = __webpack_require__(71);
+	exports.Cc  = __webpack_require__(72);
+	exports.Cf  = __webpack_require__(73);
+	exports.P   = __webpack_require__(64);
+	exports.Z   = __webpack_require__(74);
 
 
 /***/ }),
-/* 67 */
+/* 71 */
 /***/ (function(module, exports) {
 
 	module.exports=/[\0-\uD7FF\uE000-\uFFFF]|[\uD800-\uDBFF][\uDC00-\uDFFF]|[\uD800-\uDBFF](?![\uDC00-\uDFFF])|(?:[^\uD800-\uDBFF]|^)[\uDC00-\uDFFF]/
 
 /***/ }),
-/* 68 */
+/* 72 */
 /***/ (function(module, exports) {
 
 	module.exports=/[\0-\x1F\x7F-\x9F]/
 
 /***/ }),
-/* 69 */
+/* 73 */
 /***/ (function(module, exports) {
 
 	module.exports=/[\xAD\u0600-\u0605\u061C\u06DD\u070F\u08E2\u180E\u200B-\u200F\u202A-\u202E\u2060-\u2064\u2066-\u206F\uFEFF\uFFF9-\uFFFB]|\uD804\uDCBD|\uD82F[\uDCA0-\uDCA3]|\uD834[\uDD73-\uDD7A]|\uDB40[\uDC01\uDC20-\uDC7F]/
 
 /***/ }),
-/* 70 */
+/* 74 */
 /***/ (function(module, exports) {
 
 	module.exports=/[ \xA0\u1680\u2000-\u200A\u202F\u205F\u3000]/
 
 /***/ }),
-/* 71 */
+/* 75 */
 /***/ (function(module, exports, __webpack_require__) {
 
 	// Just a shortcut for bulk export
 	'use strict';
 
 
-	exports.parseLinkLabel       = __webpack_require__(72);
-	exports.parseLinkDestination = __webpack_require__(73);
-	exports.parseLinkTitle       = __webpack_require__(74);
+	exports.parseLinkLabel       = __webpack_require__(76);
+	exports.parseLinkDestination = __webpack_require__(77);
+	exports.parseLinkTitle       = __webpack_require__(78);
 
 
 /***/ }),
-/* 72 */
+/* 76 */
 /***/ (function(module, exports) {
 
 	// Parse link label
@@ -2830,7 +2873,7 @@ return /******/ (function(modules) { // webpackBootstrap
 
 
 /***/ }),
-/* 73 */
+/* 77 */
 /***/ (function(module, exports, __webpack_require__) {
 
 	// Parse link destination
@@ -2838,8 +2881,8 @@ return /******/ (function(modules) { // webpackBootstrap
 	'use strict';
 
 
-	var isSpace     = __webpack_require__(57).isSpace;
-	var unescapeAll = __webpack_require__(57).unescapeAll;
+	var isSpace     = __webpack_require__(61).isSpace;
+	var unescapeAll = __webpack_require__(61).unescapeAll;
 
 
 	module.exports = function parseLinkDestination(str, pos, max) {
@@ -2916,7 +2959,7 @@ return /******/ (function(modules) { // webpackBootstrap
 
 
 /***/ }),
-/* 74 */
+/* 78 */
 /***/ (function(module, exports, __webpack_require__) {
 
 	// Parse link title
@@ -2924,7 +2967,7 @@ return /******/ (function(modules) { // webpackBootstrap
 	'use strict';
 
 
-	var unescapeAll = __webpack_require__(57).unescapeAll;
+	var unescapeAll = __webpack_require__(61).unescapeAll;
 
 
 	module.exports = function parseLinkTitle(str, pos, max) {
@@ -2975,7 +3018,7 @@ return /******/ (function(modules) { // webpackBootstrap
 
 
 /***/ }),
-/* 75 */
+/* 79 */
 /***/ (function(module, exports, __webpack_require__) {
 
 	/**
@@ -2988,9 +3031,9 @@ return /******/ (function(modules) { // webpackBootstrap
 	'use strict';
 
 
-	var assign          = __webpack_require__(57).assign;
-	var unescapeAll     = __webpack_require__(57).unescapeAll;
-	var escapeHtml      = __webpack_require__(57).escapeHtml;
+	var assign          = __webpack_require__(61).assign;
+	var unescapeAll     = __webpack_require__(61).unescapeAll;
+	var escapeHtml      = __webpack_require__(61).escapeHtml;
 
 
 	////////////////////////////////////////////////////////////////////////////////
@@ -3318,7 +3361,7 @@ return /******/ (function(modules) { // webpackBootstrap
 
 
 /***/ }),
-/* 76 */
+/* 80 */
 /***/ (function(module, exports, __webpack_require__) {
 
 	/** internal
@@ -3330,16 +3373,16 @@ return /******/ (function(modules) { // webpackBootstrap
 	'use strict';
 
 
-	var Ruler  = __webpack_require__(77);
+	var Ruler  = __webpack_require__(81);
 
 
 	var _rules = [
-	  [ 'normalize',      __webpack_require__(78)      ],
-	  [ 'block',          __webpack_require__(79)          ],
-	  [ 'inline',         __webpack_require__(80)         ],
-	  [ 'linkify',        __webpack_require__(81)        ],
-	  [ 'replacements',   __webpack_require__(82)   ],
-	  [ 'smartquotes',    __webpack_require__(83)    ]
+	  [ 'normalize',      __webpack_require__(82)      ],
+	  [ 'block',          __webpack_require__(83)          ],
+	  [ 'inline',         __webpack_require__(84)         ],
+	  [ 'linkify',        __webpack_require__(85)        ],
+	  [ 'replacements',   __webpack_require__(86)   ],
+	  [ 'smartquotes',    __webpack_require__(87)    ]
 	];
 
 
@@ -3375,14 +3418,14 @@ return /******/ (function(modules) { // webpackBootstrap
 	  }
 	};
 
-	Core.prototype.State = __webpack_require__(84);
+	Core.prototype.State = __webpack_require__(88);
 
 
 	module.exports = Core;
 
 
 /***/ }),
-/* 77 */
+/* 81 */
 /***/ (function(module, exports) {
 
 	/**
@@ -3740,7 +3783,7 @@ return /******/ (function(modules) { // webpackBootstrap
 
 
 /***/ }),
-/* 78 */
+/* 82 */
 /***/ (function(module, exports) {
 
 	// Normalize input string
@@ -3766,7 +3809,7 @@ return /******/ (function(modules) { // webpackBootstrap
 
 
 /***/ }),
-/* 79 */
+/* 83 */
 /***/ (function(module, exports) {
 
 	'use strict';
@@ -3788,7 +3831,7 @@ return /******/ (function(modules) { // webpackBootstrap
 
 
 /***/ }),
-/* 80 */
+/* 84 */
 /***/ (function(module, exports) {
 
 	'use strict';
@@ -3807,7 +3850,7 @@ return /******/ (function(modules) { // webpackBootstrap
 
 
 /***/ }),
-/* 81 */
+/* 85 */
 /***/ (function(module, exports, __webpack_require__) {
 
 	// Replace link-like texts with link nodes.
@@ -3817,7 +3860,7 @@ return /******/ (function(modules) { // webpackBootstrap
 	'use strict';
 
 
-	var arrayReplaceAt = __webpack_require__(57).arrayReplaceAt;
+	var arrayReplaceAt = __webpack_require__(61).arrayReplaceAt;
 
 
 	function isLinkOpen(str) {
@@ -3946,7 +3989,7 @@ return /******/ (function(modules) { // webpackBootstrap
 
 
 /***/ }),
-/* 82 */
+/* 86 */
 /***/ (function(module, exports) {
 
 	// Simple typographyc replacements
@@ -4041,7 +4084,7 @@ return /******/ (function(modules) { // webpackBootstrap
 
 
 /***/ }),
-/* 83 */
+/* 87 */
 /***/ (function(module, exports, __webpack_require__) {
 
 	// Convert straight quotation marks to typographic ones
@@ -4049,9 +4092,9 @@ return /******/ (function(modules) { // webpackBootstrap
 	'use strict';
 
 
-	var isWhiteSpace   = __webpack_require__(57).isWhiteSpace;
-	var isPunctChar    = __webpack_require__(57).isPunctChar;
-	var isMdAsciiPunct = __webpack_require__(57).isMdAsciiPunct;
+	var isWhiteSpace   = __webpack_require__(61).isWhiteSpace;
+	var isPunctChar    = __webpack_require__(61).isPunctChar;
+	var isMdAsciiPunct = __webpack_require__(61).isMdAsciiPunct;
 
 	var QUOTE_TEST_RE = /['"]/;
 	var QUOTE_RE = /['"]/g;
@@ -4240,14 +4283,14 @@ return /******/ (function(modules) { // webpackBootstrap
 
 
 /***/ }),
-/* 84 */
+/* 88 */
 /***/ (function(module, exports, __webpack_require__) {
 
 	// Core state object
 	//
 	'use strict';
 
-	var Token = __webpack_require__(85);
+	var Token = __webpack_require__(89);
 
 
 	function StateCore(src, md, env) {
@@ -4266,7 +4309,7 @@ return /******/ (function(modules) { // webpackBootstrap
 
 
 /***/ }),
-/* 85 */
+/* 89 */
 /***/ (function(module, exports) {
 
 	// Token class
@@ -4469,7 +4512,7 @@ return /******/ (function(modules) { // webpackBootstrap
 
 
 /***/ }),
-/* 86 */
+/* 90 */
 /***/ (function(module, exports, __webpack_require__) {
 
 	/** internal
@@ -4480,23 +4523,23 @@ return /******/ (function(modules) { // webpackBootstrap
 	'use strict';
 
 
-	var Ruler           = __webpack_require__(77);
+	var Ruler           = __webpack_require__(81);
 
 
 	var _rules = [
 	  // First 2 params - rule name & source. Secondary array - list of rules,
 	  // which can be terminated by this one.
-	  [ 'table',      __webpack_require__(87),      [ 'paragraph', 'reference' ] ],
-	  [ 'code',       __webpack_require__(88) ],
-	  [ 'fence',      __webpack_require__(89),      [ 'paragraph', 'reference', 'blockquote', 'list' ] ],
-	  [ 'blockquote', __webpack_require__(90), [ 'paragraph', 'reference', 'list' ] ],
-	  [ 'hr',         __webpack_require__(91),         [ 'paragraph', 'reference', 'blockquote', 'list' ] ],
-	  [ 'list',       __webpack_require__(92),       [ 'paragraph', 'reference', 'blockquote' ] ],
-	  [ 'reference',  __webpack_require__(93) ],
-	  [ 'heading',    __webpack_require__(94),    [ 'paragraph', 'reference', 'blockquote' ] ],
-	  [ 'lheading',   __webpack_require__(95) ],
-	  [ 'html_block', __webpack_require__(96), [ 'paragraph', 'reference', 'blockquote' ] ],
-	  [ 'paragraph',  __webpack_require__(99) ]
+	  [ 'table',      __webpack_require__(91),      [ 'paragraph', 'reference' ] ],
+	  [ 'code',       __webpack_require__(92) ],
+	  [ 'fence',      __webpack_require__(93),      [ 'paragraph', 'reference', 'blockquote', 'list' ] ],
+	  [ 'blockquote', __webpack_require__(94), [ 'paragraph', 'reference', 'list' ] ],
+	  [ 'hr',         __webpack_require__(95),         [ 'paragraph', 'reference', 'blockquote', 'list' ] ],
+	  [ 'list',       __webpack_require__(96),       [ 'paragraph', 'reference', 'blockquote' ] ],
+	  [ 'reference',  __webpack_require__(97) ],
+	  [ 'heading',    __webpack_require__(98),    [ 'paragraph', 'reference', 'blockquote' ] ],
+	  [ 'lheading',   __webpack_require__(99) ],
+	  [ 'html_block', __webpack_require__(100), [ 'paragraph', 'reference', 'blockquote' ] ],
+	  [ 'paragraph',  __webpack_require__(103) ]
 	];
 
 
@@ -4593,14 +4636,14 @@ return /******/ (function(modules) { // webpackBootstrap
 	};
 
 
-	ParserBlock.prototype.State = __webpack_require__(100);
+	ParserBlock.prototype.State = __webpack_require__(104);
 
 
 	module.exports = ParserBlock;
 
 
 /***/ }),
-/* 87 */
+/* 91 */
 /***/ (function(module, exports) {
 
 	// GFM table, non-standard
@@ -4780,7 +4823,7 @@ return /******/ (function(modules) { // webpackBootstrap
 
 
 /***/ }),
-/* 88 */
+/* 92 */
 /***/ (function(module, exports) {
 
 	// Code block (4 spaces padded)
@@ -4830,7 +4873,7 @@ return /******/ (function(modules) { // webpackBootstrap
 
 
 /***/ }),
-/* 89 */
+/* 93 */
 /***/ (function(module, exports) {
 
 	// fences (``` lang, ~~~ lang)
@@ -4927,14 +4970,14 @@ return /******/ (function(modules) { // webpackBootstrap
 
 
 /***/ }),
-/* 90 */
+/* 94 */
 /***/ (function(module, exports, __webpack_require__) {
 
 	// Block quotes
 
 	'use strict';
 
-	var isSpace = __webpack_require__(57).isSpace;
+	var isSpace = __webpack_require__(61).isSpace;
 
 
 	module.exports = function blockquote(state, startLine, endLine, silent) {
@@ -5107,14 +5150,14 @@ return /******/ (function(modules) { // webpackBootstrap
 
 
 /***/ }),
-/* 91 */
+/* 95 */
 /***/ (function(module, exports, __webpack_require__) {
 
 	// Horizontal rule
 
 	'use strict';
 
-	var isSpace = __webpack_require__(57).isSpace;
+	var isSpace = __webpack_require__(61).isSpace;
 
 
 	module.exports = function hr(state, startLine, endLine, silent) {
@@ -5155,14 +5198,14 @@ return /******/ (function(modules) { // webpackBootstrap
 
 
 /***/ }),
-/* 92 */
+/* 96 */
 /***/ (function(module, exports, __webpack_require__) {
 
 	// Lists
 
 	'use strict';
 
-	var isSpace = __webpack_require__(57).isSpace;
+	var isSpace = __webpack_require__(61).isSpace;
 
 
 	// Search `[-+*][\n ]`, returns next pos arter marker on success
@@ -5471,16 +5514,16 @@ return /******/ (function(modules) { // webpackBootstrap
 
 
 /***/ }),
-/* 93 */
+/* 97 */
 /***/ (function(module, exports, __webpack_require__) {
 
 	'use strict';
 
 
-	var parseLinkDestination = __webpack_require__(73);
-	var parseLinkTitle       = __webpack_require__(74);
-	var normalizeReference   = __webpack_require__(57).normalizeReference;
-	var isSpace              = __webpack_require__(57).isSpace;
+	var parseLinkDestination = __webpack_require__(77);
+	var parseLinkTitle       = __webpack_require__(78);
+	var normalizeReference   = __webpack_require__(61).normalizeReference;
+	var isSpace              = __webpack_require__(61).isSpace;
 
 
 	module.exports = function reference(state, startLine, _endLine, silent) {
@@ -5668,14 +5711,14 @@ return /******/ (function(modules) { // webpackBootstrap
 
 
 /***/ }),
-/* 94 */
+/* 98 */
 /***/ (function(module, exports, __webpack_require__) {
 
 	// heading (#, ##, ...)
 
 	'use strict';
 
-	var isSpace = __webpack_require__(57).isSpace;
+	var isSpace = __webpack_require__(61).isSpace;
 
 
 	module.exports = function heading(state, startLine, endLine, silent) {
@@ -5726,7 +5769,7 @@ return /******/ (function(modules) { // webpackBootstrap
 
 
 /***/ }),
-/* 95 */
+/* 99 */
 /***/ (function(module, exports) {
 
 	// lheading (---, ===)
@@ -5807,7 +5850,7 @@ return /******/ (function(modules) { // webpackBootstrap
 
 
 /***/ }),
-/* 96 */
+/* 100 */
 /***/ (function(module, exports, __webpack_require__) {
 
 	// HTML block
@@ -5815,8 +5858,8 @@ return /******/ (function(modules) { // webpackBootstrap
 	'use strict';
 
 
-	var block_names = __webpack_require__(97);
-	var HTML_OPEN_CLOSE_TAG_RE = __webpack_require__(98).HTML_OPEN_CLOSE_TAG_RE;
+	var block_names = __webpack_require__(101);
+	var HTML_OPEN_CLOSE_TAG_RE = __webpack_require__(102).HTML_OPEN_CLOSE_TAG_RE;
 
 	// An array of opening and corresponding closing sequences for html tags,
 	// last argument defines whether it can terminate a paragraph or not
@@ -5884,7 +5927,7 @@ return /******/ (function(modules) { // webpackBootstrap
 
 
 /***/ }),
-/* 97 */
+/* 101 */
 /***/ (function(module, exports) {
 
 	// List of valid html blocks names, accorting to commonmark spec
@@ -5958,7 +6001,7 @@ return /******/ (function(modules) { // webpackBootstrap
 
 
 /***/ }),
-/* 98 */
+/* 102 */
 /***/ (function(module, exports) {
 
 	// Regexps to match html elements
@@ -5992,7 +6035,7 @@ return /******/ (function(modules) { // webpackBootstrap
 
 
 /***/ }),
-/* 99 */
+/* 103 */
 /***/ (function(module, exports) {
 
 	// Paragraph
@@ -6045,15 +6088,15 @@ return /******/ (function(modules) { // webpackBootstrap
 
 
 /***/ }),
-/* 100 */
+/* 104 */
 /***/ (function(module, exports, __webpack_require__) {
 
 	// Parser state class
 
 	'use strict';
 
-	var Token = __webpack_require__(85);
-	var isSpace = __webpack_require__(57).isSpace;
+	var Token = __webpack_require__(89);
+	var isSpace = __webpack_require__(61).isSpace;
 
 
 	function StateBlock(src, md, env, tokens) {
@@ -6258,7 +6301,7 @@ return /******/ (function(modules) { // webpackBootstrap
 
 
 /***/ }),
-/* 101 */
+/* 105 */
 /***/ (function(module, exports, __webpack_require__) {
 
 	/** internal
@@ -6269,31 +6312,31 @@ return /******/ (function(modules) { // webpackBootstrap
 	'use strict';
 
 
-	var Ruler           = __webpack_require__(77);
+	var Ruler           = __webpack_require__(81);
 
 
 	////////////////////////////////////////////////////////////////////////////////
 	// Parser rules
 
 	var _rules = [
-	  [ 'text',            __webpack_require__(102) ],
-	  [ 'newline',         __webpack_require__(103) ],
-	  [ 'escape',          __webpack_require__(104) ],
-	  [ 'backticks',       __webpack_require__(105) ],
-	  [ 'strikethrough',   __webpack_require__(106).tokenize ],
-	  [ 'emphasis',        __webpack_require__(107).tokenize ],
-	  [ 'link',            __webpack_require__(108) ],
-	  [ 'image',           __webpack_require__(109) ],
-	  [ 'autolink',        __webpack_require__(110) ],
-	  [ 'html_inline',     __webpack_require__(111) ],
-	  [ 'entity',          __webpack_require__(112) ]
+	  [ 'text',            __webpack_require__(106) ],
+	  [ 'newline',         __webpack_require__(107) ],
+	  [ 'escape',          __webpack_require__(108) ],
+	  [ 'backticks',       __webpack_require__(109) ],
+	  [ 'strikethrough',   __webpack_require__(110).tokenize ],
+	  [ 'emphasis',        __webpack_require__(111).tokenize ],
+	  [ 'link',            __webpack_require__(112) ],
+	  [ 'image',           __webpack_require__(113) ],
+	  [ 'autolink',        __webpack_require__(114) ],
+	  [ 'html_inline',     __webpack_require__(115) ],
+	  [ 'entity',          __webpack_require__(116) ]
 	];
 
 	var _rules2 = [
-	  [ 'balance_pairs',   __webpack_require__(113) ],
-	  [ 'strikethrough',   __webpack_require__(106).postProcess ],
-	  [ 'emphasis',        __webpack_require__(107).postProcess ],
-	  [ 'text_collapse',   __webpack_require__(114) ]
+	  [ 'balance_pairs',   __webpack_require__(117) ],
+	  [ 'strikethrough',   __webpack_require__(110).postProcess ],
+	  [ 'emphasis',        __webpack_require__(111).postProcess ],
+	  [ 'text_collapse',   __webpack_require__(118) ]
 	];
 
 
@@ -6434,14 +6477,14 @@ return /******/ (function(modules) { // webpackBootstrap
 	};
 
 
-	ParserInline.prototype.State = __webpack_require__(115);
+	ParserInline.prototype.State = __webpack_require__(119);
 
 
 	module.exports = ParserInline;
 
 
 /***/ }),
-/* 102 */
+/* 106 */
 /***/ (function(module, exports) {
 
 	// Skip text characters for text token, place those to pending buffer
@@ -6536,7 +6579,7 @@ return /******/ (function(modules) { // webpackBootstrap
 
 
 /***/ }),
-/* 103 */
+/* 107 */
 /***/ (function(module, exports) {
 
 	// Proceess '\n'
@@ -6581,14 +6624,14 @@ return /******/ (function(modules) { // webpackBootstrap
 
 
 /***/ }),
-/* 104 */
+/* 108 */
 /***/ (function(module, exports, __webpack_require__) {
 
 	// Proceess escaped chars and hardbreaks
 
 	'use strict';
 
-	var isSpace = __webpack_require__(57).isSpace;
+	var isSpace = __webpack_require__(61).isSpace;
 
 	var ESCAPED = [];
 
@@ -6639,7 +6682,7 @@ return /******/ (function(modules) { // webpackBootstrap
 
 
 /***/ }),
-/* 105 */
+/* 109 */
 /***/ (function(module, exports) {
 
 	// Parse backticks
@@ -6688,7 +6731,7 @@ return /******/ (function(modules) { // webpackBootstrap
 
 
 /***/ }),
-/* 106 */
+/* 110 */
 /***/ (function(module, exports) {
 
 	// ~~strike through~~
@@ -6811,7 +6854,7 @@ return /******/ (function(modules) { // webpackBootstrap
 
 
 /***/ }),
-/* 107 */
+/* 111 */
 /***/ (function(module, exports) {
 
 	// Process *this* and _that_
@@ -6940,18 +6983,18 @@ return /******/ (function(modules) { // webpackBootstrap
 
 
 /***/ }),
-/* 108 */
+/* 112 */
 /***/ (function(module, exports, __webpack_require__) {
 
 	// Process [link](<to> "stuff")
 
 	'use strict';
 
-	var parseLinkLabel       = __webpack_require__(72);
-	var parseLinkDestination = __webpack_require__(73);
-	var parseLinkTitle       = __webpack_require__(74);
-	var normalizeReference   = __webpack_require__(57).normalizeReference;
-	var isSpace              = __webpack_require__(57).isSpace;
+	var parseLinkLabel       = __webpack_require__(76);
+	var parseLinkDestination = __webpack_require__(77);
+	var parseLinkTitle       = __webpack_require__(78);
+	var normalizeReference   = __webpack_require__(61).normalizeReference;
+	var isSpace              = __webpack_require__(61).isSpace;
 
 
 	module.exports = function link(state, silent) {
@@ -7093,18 +7136,18 @@ return /******/ (function(modules) { // webpackBootstrap
 
 
 /***/ }),
-/* 109 */
+/* 113 */
 /***/ (function(module, exports, __webpack_require__) {
 
 	// Process ![image](<src> "title")
 
 	'use strict';
 
-	var parseLinkLabel       = __webpack_require__(72);
-	var parseLinkDestination = __webpack_require__(73);
-	var parseLinkTitle       = __webpack_require__(74);
-	var normalizeReference   = __webpack_require__(57).normalizeReference;
-	var isSpace              = __webpack_require__(57).isSpace;
+	var parseLinkLabel       = __webpack_require__(76);
+	var parseLinkDestination = __webpack_require__(77);
+	var parseLinkTitle       = __webpack_require__(78);
+	var normalizeReference   = __webpack_require__(61).normalizeReference;
+	var isSpace              = __webpack_require__(61).isSpace;
 
 
 	module.exports = function image(state, silent) {
@@ -7254,7 +7297,7 @@ return /******/ (function(modules) { // webpackBootstrap
 
 
 /***/ }),
-/* 110 */
+/* 114 */
 /***/ (function(module, exports) {
 
 	// Process autolinks '<protocol:...>'
@@ -7332,7 +7375,7 @@ return /******/ (function(modules) { // webpackBootstrap
 
 
 /***/ }),
-/* 111 */
+/* 115 */
 /***/ (function(module, exports, __webpack_require__) {
 
 	// Process html tags
@@ -7340,7 +7383,7 @@ return /******/ (function(modules) { // webpackBootstrap
 	'use strict';
 
 
-	var HTML_TAG_RE = __webpack_require__(98).HTML_TAG_RE;
+	var HTML_TAG_RE = __webpack_require__(102).HTML_TAG_RE;
 
 
 	function isLetter(ch) {
@@ -7385,17 +7428,17 @@ return /******/ (function(modules) { // webpackBootstrap
 
 
 /***/ }),
-/* 112 */
+/* 116 */
 /***/ (function(module, exports, __webpack_require__) {
 
 	// Process html entity - &#123;, &#xAF;, &quot;, ...
 
 	'use strict';
 
-	var entities          = __webpack_require__(58);
-	var has               = __webpack_require__(57).has;
-	var isValidEntityCode = __webpack_require__(57).isValidEntityCode;
-	var fromCodePoint     = __webpack_require__(57).fromCodePoint;
+	var entities          = __webpack_require__(62);
+	var has               = __webpack_require__(61).has;
+	var isValidEntityCode = __webpack_require__(61).isValidEntityCode;
+	var fromCodePoint     = __webpack_require__(61).fromCodePoint;
 
 
 	var DIGITAL_RE = /^&#((?:x[a-f0-9]{1,8}|[0-9]{1,8}));/i;
@@ -7439,7 +7482,7 @@ return /******/ (function(modules) { // webpackBootstrap
 
 
 /***/ }),
-/* 113 */
+/* 117 */
 /***/ (function(module, exports) {
 
 	// For each opening emphasis-like marker find a matching closing one
@@ -7481,7 +7524,7 @@ return /******/ (function(modules) { // webpackBootstrap
 
 
 /***/ }),
-/* 114 */
+/* 118 */
 /***/ (function(module, exports) {
 
 	// Merge adjacent text nodes into one, and re-calculate all token levels
@@ -7520,7 +7563,7 @@ return /******/ (function(modules) { // webpackBootstrap
 
 
 /***/ }),
-/* 115 */
+/* 119 */
 /***/ (function(module, exports, __webpack_require__) {
 
 	// Inline parser state
@@ -7528,10 +7571,10 @@ return /******/ (function(modules) { // webpackBootstrap
 	'use strict';
 
 
-	var Token          = __webpack_require__(85);
-	var isWhiteSpace   = __webpack_require__(57).isWhiteSpace;
-	var isPunctChar    = __webpack_require__(57).isPunctChar;
-	var isMdAsciiPunct = __webpack_require__(57).isMdAsciiPunct;
+	var Token          = __webpack_require__(89);
+	var isWhiteSpace   = __webpack_require__(61).isWhiteSpace;
+	var isPunctChar    = __webpack_require__(61).isPunctChar;
+	var isMdAsciiPunct = __webpack_require__(61).isMdAsciiPunct;
 
 
 	function StateInline(src, md, env, outTokens) {
@@ -7656,7 +7699,7 @@ return /******/ (function(modules) { // webpackBootstrap
 
 
 /***/ }),
-/* 116 */
+/* 120 */
 /***/ (function(module, exports, __webpack_require__) {
 
 	'use strict';
@@ -7811,7 +7854,7 @@ return /******/ (function(modules) { // webpackBootstrap
 	function compile(self) {
 
 	  // Load & clone RE patterns.
-	  var re = self.re = assign({}, __webpack_require__(117));
+	  var re = self.re = assign({}, __webpack_require__(121));
 
 	  // Define dynamic patterns
 	  var tlds = self.__tlds__.slice();
@@ -8288,16 +8331,16 @@ return /******/ (function(modules) { // webpackBootstrap
 
 
 /***/ }),
-/* 117 */
+/* 121 */
 /***/ (function(module, exports, __webpack_require__) {
 
 	'use strict';
 
 	// Use direct extract instead of `regenerate` to reduse browserified size
-	var src_Any = exports.src_Any = __webpack_require__(67).source;
-	var src_Cc  = exports.src_Cc = __webpack_require__(68).source;
-	var src_Z   = exports.src_Z  = __webpack_require__(70).source;
-	var src_P   = exports.src_P  = __webpack_require__(60).source;
+	var src_Any = exports.src_Any = __webpack_require__(71).source;
+	var src_Cc  = exports.src_Cc = __webpack_require__(72).source;
+	var src_Z   = exports.src_Z  = __webpack_require__(74).source;
+	var src_P   = exports.src_P  = __webpack_require__(64).source;
 
 	// \p{\Z\P\Cc\CF} (white spaces + control + format + punctuation)
 	var src_ZPCc = exports.src_ZPCc = [ src_Z, src_P, src_Cc ].join('|');
@@ -8456,7 +8499,7 @@ return /******/ (function(modules) { // webpackBootstrap
 
 
 /***/ }),
-/* 118 */
+/* 122 */
 /***/ (function(module, exports, __webpack_require__) {
 
 	var __WEBPACK_AMD_DEFINE_RESULT__;/* WEBPACK VAR INJECTION */(function(module, global) {/*! https://mths.be/punycode v1.4.1 by @mathias */
@@ -8991,10 +9034,10 @@ return /******/ (function(modules) { // webpackBootstrap
 
 	}(this));
 
-	/* WEBPACK VAR INJECTION */}.call(exports, __webpack_require__(119)(module), (function() { return this; }())))
+	/* WEBPACK VAR INJECTION */}.call(exports, __webpack_require__(123)(module), (function() { return this; }())))
 
 /***/ }),
-/* 119 */
+/* 123 */
 /***/ (function(module, exports) {
 
 	module.exports = function(module) {
@@ -9010,7 +9053,7 @@ return /******/ (function(modules) { // webpackBootstrap
 
 
 /***/ }),
-/* 120 */
+/* 124 */
 /***/ (function(module, exports) {
 
 	// markdown-it default options
@@ -9057,7 +9100,7 @@ return /******/ (function(modules) { // webpackBootstrap
 
 
 /***/ }),
-/* 121 */
+/* 125 */
 /***/ (function(module, exports) {
 
 	// "Zero" preset, with nothing enabled. Useful for manual configuring of simple
@@ -9125,7 +9168,7 @@ return /******/ (function(modules) { // webpackBootstrap
 
 
 /***/ }),
-/* 122 */
+/* 126 */
 /***/ (function(module, exports) {
 
 	// Commonmark default options
@@ -9211,17 +9254,17 @@ return /******/ (function(modules) { // webpackBootstrap
 
 
 /***/ }),
-/* 123 */
+/* 127 */
 /***/ (function(module, exports, __webpack_require__) {
 
 	'use strict';
 
 
-	var emojies_defs      = __webpack_require__(124);
-	var emojies_shortcuts = __webpack_require__(125);
-	var emoji_html        = __webpack_require__(126);
-	var emoji_replace     = __webpack_require__(127);
-	var normalize_opts    = __webpack_require__(128);
+	var emojies_defs      = __webpack_require__(128);
+	var emojies_shortcuts = __webpack_require__(129);
+	var emoji_html        = __webpack_require__(130);
+	var emoji_replace     = __webpack_require__(131);
+	var normalize_opts    = __webpack_require__(132);
 
 
 	module.exports = function emoji_plugin(md, options) {
@@ -9240,13 +9283,13 @@ return /******/ (function(modules) { // webpackBootstrap
 
 
 /***/ }),
-/* 124 */
+/* 128 */
 /***/ (function(module, exports) {
 
 	module.exports = {"100":"💯","1234":"🔢","grinning":"😀","smiley":"😃","smile":"😄","grin":"😁","laughing":"😆","satisfied":"😆","sweat_smile":"😅","joy":"😂","rofl":"🤣","relaxed":"☺️","blush":"😊","innocent":"😇","slightly_smiling_face":"🙂","upside_down_face":"🙃","wink":"😉","relieved":"😌","heart_eyes":"😍","kissing_heart":"😘","kissing":"😗","kissing_smiling_eyes":"😙","kissing_closed_eyes":"😚","yum":"😋","stuck_out_tongue_winking_eye":"😜","stuck_out_tongue_closed_eyes":"😝","stuck_out_tongue":"😛","money_mouth_face":"🤑","hugs":"🤗","nerd_face":"🤓","sunglasses":"😎","clown_face":"🤡","cowboy_hat_face":"🤠","smirk":"😏","unamused":"😒","disappointed":"😞","pensive":"😔","worried":"😟","confused":"😕","slightly_frowning_face":"🙁","frowning_face":"☹️","persevere":"😣","confounded":"😖","tired_face":"😫","weary":"😩","triumph":"😤","angry":"😠","rage":"😡","pout":"😡","no_mouth":"😶","neutral_face":"😐","expressionless":"😑","hushed":"😯","frowning":"😦","anguished":"😧","open_mouth":"😮","astonished":"😲","dizzy_face":"😵","flushed":"😳","scream":"😱","fearful":"😨","cold_sweat":"😰","cry":"😢","disappointed_relieved":"😥","drooling_face":"🤤","sob":"😭","sweat":"😓","sleepy":"😪","sleeping":"😴","roll_eyes":"🙄","thinking":"🤔","lying_face":"🤥","grimacing":"😬","zipper_mouth_face":"🤐","nauseated_face":"🤢","sneezing_face":"🤧","mask":"😷","face_with_thermometer":"🤒","face_with_head_bandage":"🤕","smiling_imp":"😈","imp":"👿","japanese_ogre":"👹","japanese_goblin":"👺","hankey":"💩","poop":"💩","shit":"💩","ghost":"👻","skull":"💀","skull_and_crossbones":"☠️","alien":"👽","space_invader":"👾","robot":"🤖","jack_o_lantern":"🎃","smiley_cat":"😺","smile_cat":"😸","joy_cat":"😹","heart_eyes_cat":"😻","smirk_cat":"😼","kissing_cat":"😽","scream_cat":"🙀","crying_cat_face":"😿","pouting_cat":"😾","open_hands":"👐","raised_hands":"🙌","clap":"👏","pray":"🙏","handshake":"🤝","+1":"👍","thumbsup":"👍","-1":"👎","thumbsdown":"👎","fist_oncoming":"👊","facepunch":"👊","punch":"👊","fist_raised":"✊","fist":"✊","fist_left":"🤛","fist_right":"🤜","crossed_fingers":"🤞","v":"✌️","metal":"🤘","ok_hand":"👌","point_left":"👈","point_right":"👉","point_up_2":"👆","point_down":"👇","point_up":"☝️","hand":"✋","raised_hand":"✋","raised_back_of_hand":"🤚","raised_hand_with_fingers_splayed":"🖐","vulcan_salute":"🖖","wave":"👋","call_me_hand":"🤙","muscle":"💪","middle_finger":"🖕","fu":"🖕","writing_hand":"✍️","selfie":"🤳","nail_care":"💅","ring":"💍","lipstick":"💄","kiss":"💋","lips":"👄","tongue":"👅","ear":"👂","nose":"👃","footprints":"👣","eye":"👁","eyes":"👀","speaking_head":"🗣","bust_in_silhouette":"👤","busts_in_silhouette":"👥","baby":"👶","boy":"👦","girl":"👧","man":"👨","woman":"👩","blonde_woman":"👱‍♀","blonde_man":"👱","person_with_blond_hair":"👱","older_man":"👴","older_woman":"👵","man_with_gua_pi_mao":"👲","woman_with_turban":"👳‍♀","man_with_turban":"👳","policewoman":"👮‍♀","policeman":"👮","cop":"👮","construction_worker_woman":"👷‍♀","construction_worker_man":"👷","construction_worker":"👷","guardswoman":"💂‍♀","guardsman":"💂","female_detective":"🕵️‍♀️","male_detective":"🕵","detective":"🕵","woman_health_worker":"👩‍⚕","man_health_worker":"👨‍⚕","woman_farmer":"👩‍🌾","man_farmer":"👨‍🌾","woman_cook":"👩‍🍳","man_cook":"👨‍🍳","woman_student":"👩‍🎓","man_student":"👨‍🎓","woman_singer":"👩‍🎤","man_singer":"👨‍🎤","woman_teacher":"👩‍🏫","man_teacher":"👨‍🏫","woman_factory_worker":"👩‍🏭","man_factory_worker":"👨‍🏭","woman_technologist":"👩‍💻","man_technologist":"👨‍💻","woman_office_worker":"👩‍💼","man_office_worker":"👨‍💼","woman_mechanic":"👩‍🔧","man_mechanic":"👨‍🔧","woman_scientist":"👩‍🔬","man_scientist":"👨‍🔬","woman_artist":"👩‍🎨","man_artist":"👨‍🎨","woman_firefighter":"👩‍🚒","man_firefighter":"👨‍🚒","woman_pilot":"👩‍✈","man_pilot":"👨‍✈","woman_astronaut":"👩‍🚀","man_astronaut":"👨‍🚀","woman_judge":"👩‍⚖","man_judge":"👨‍⚖","mrs_claus":"🤶","santa":"🎅","princess":"👸","prince":"🤴","bride_with_veil":"👰","man_in_tuxedo":"🤵","angel":"👼","pregnant_woman":"🤰","bowing_woman":"🙇‍♀","bowing_man":"🙇","bow":"🙇","tipping_hand_woman":"💁","information_desk_person":"💁","sassy_woman":"💁","tipping_hand_man":"💁‍♂","sassy_man":"💁‍♂","no_good_woman":"🙅","no_good":"🙅","ng_woman":"🙅","no_good_man":"🙅‍♂","ng_man":"🙅‍♂","ok_woman":"🙆","ok_man":"🙆‍♂","raising_hand_woman":"🙋","raising_hand":"🙋","raising_hand_man":"🙋‍♂","woman_facepalming":"🤦‍♀","man_facepalming":"🤦‍♂","woman_shrugging":"🤷‍♀","man_shrugging":"🤷‍♂","pouting_woman":"🙎","person_with_pouting_face":"🙎","pouting_man":"🙎‍♂","frowning_woman":"🙍","person_frowning":"🙍","frowning_man":"🙍‍♂","haircut_woman":"💇","haircut":"💇","haircut_man":"💇‍♂","massage_woman":"💆","massage":"💆","massage_man":"💆‍♂","business_suit_levitating":"🕴","dancer":"💃","man_dancing":"🕺","dancing_women":"👯","dancers":"👯","dancing_men":"👯‍♂","walking_woman":"🚶‍♀","walking_man":"🚶","walking":"🚶","running_woman":"🏃‍♀","running_man":"🏃","runner":"🏃","running":"🏃","couple":"👫","two_women_holding_hands":"👭","two_men_holding_hands":"👬","couple_with_heart_woman_man":"💑","couple_with_heart":"💑","couple_with_heart_woman_woman":"👩‍❤️‍👩","couple_with_heart_man_man":"👨‍❤️‍👨","couplekiss_man_woman":"💏","couplekiss_woman_woman":"👩‍❤️‍💋‍👩","couplekiss_man_man":"👨‍❤️‍💋‍👨","family_man_woman_boy":"👪","family":"👪","family_man_woman_girl":"👨‍👩‍👧","family_man_woman_girl_boy":"👨‍👩‍👧‍👦","family_man_woman_boy_boy":"👨‍👩‍👦‍👦","family_man_woman_girl_girl":"👨‍👩‍👧‍👧","family_woman_woman_boy":"👩‍👩‍👦","family_woman_woman_girl":"👩‍👩‍👧","family_woman_woman_girl_boy":"👩‍👩‍👧‍👦","family_woman_woman_boy_boy":"👩‍👩‍👦‍👦","family_woman_woman_girl_girl":"👩‍👩‍👧‍👧","family_man_man_boy":"👨‍👨‍👦","family_man_man_girl":"👨‍👨‍👧","family_man_man_girl_boy":"👨‍👨‍👧‍👦","family_man_man_boy_boy":"👨‍👨‍👦‍👦","family_man_man_girl_girl":"👨‍👨‍👧‍👧","family_woman_boy":"👩‍👦","family_woman_girl":"👩‍👧","family_woman_girl_boy":"👩‍👧‍👦","family_woman_boy_boy":"👩‍👦‍👦","family_woman_girl_girl":"👩‍👧‍👧","family_man_boy":"👨‍👦","family_man_girl":"👨‍👧","family_man_girl_boy":"👨‍👧‍👦","family_man_boy_boy":"👨‍👦‍👦","family_man_girl_girl":"👨‍👧‍👧","womans_clothes":"👚","shirt":"👕","tshirt":"👕","jeans":"👖","necktie":"👔","dress":"👗","bikini":"👙","kimono":"👘","high_heel":"👠","sandal":"👡","boot":"👢","mans_shoe":"👞","shoe":"👞","athletic_shoe":"👟","womans_hat":"👒","tophat":"🎩","mortar_board":"🎓","crown":"👑","rescue_worker_helmet":"⛑","school_satchel":"🎒","pouch":"👝","purse":"👛","handbag":"👜","briefcase":"💼","eyeglasses":"👓","dark_sunglasses":"🕶","closed_umbrella":"🌂","open_umbrella":"☂️","dog":"🐶","cat":"🐱","mouse":"🐭","hamster":"🐹","rabbit":"🐰","fox_face":"🦊","bear":"🐻","panda_face":"🐼","koala":"🐨","tiger":"🐯","lion":"🦁","cow":"🐮","pig":"🐷","pig_nose":"🐽","frog":"🐸","monkey_face":"🐵","see_no_evil":"🙈","hear_no_evil":"🙉","speak_no_evil":"🙊","monkey":"🐒","chicken":"🐔","penguin":"🐧","bird":"🐦","baby_chick":"🐤","hatching_chick":"🐣","hatched_chick":"🐥","duck":"🦆","eagle":"🦅","owl":"🦉","bat":"🦇","wolf":"🐺","boar":"🐗","horse":"🐴","unicorn":"🦄","bee":"🐝","honeybee":"🐝","bug":"🐛","butterfly":"🦋","snail":"🐌","shell":"🐚","beetle":"🐞","ant":"🐜","spider":"🕷","spider_web":"🕸","turtle":"🐢","snake":"🐍","lizard":"🦎","scorpion":"🦂","crab":"🦀","squid":"🦑","octopus":"🐙","shrimp":"🦐","tropical_fish":"🐠","fish":"🐟","blowfish":"🐡","dolphin":"🐬","flipper":"🐬","shark":"🦈","whale":"🐳","whale2":"🐋","crocodile":"🐊","leopard":"🐆","tiger2":"🐅","water_buffalo":"🐃","ox":"🐂","cow2":"🐄","deer":"🦌","dromedary_camel":"🐪","camel":"🐫","elephant":"🐘","rhinoceros":"🦏","gorilla":"🦍","racehorse":"🐎","pig2":"🐖","goat":"🐐","ram":"🐏","sheep":"🐑","dog2":"🐕","poodle":"🐩","cat2":"🐈","rooster":"🐓","turkey":"🦃","dove":"🕊","rabbit2":"🐇","mouse2":"🐁","rat":"🐀","chipmunk":"🐿","feet":"🐾","paw_prints":"🐾","dragon":"🐉","dragon_face":"🐲","cactus":"🌵","christmas_tree":"🎄","evergreen_tree":"🌲","deciduous_tree":"🌳","palm_tree":"🌴","seedling":"🌱","herb":"🌿","shamrock":"☘️","four_leaf_clover":"🍀","bamboo":"🎍","tanabata_tree":"🎋","leaves":"🍃","fallen_leaf":"🍂","maple_leaf":"🍁","mushroom":"🍄","ear_of_rice":"🌾","bouquet":"💐","tulip":"🌷","rose":"🌹","wilted_flower":"🥀","sunflower":"🌻","blossom":"🌼","cherry_blossom":"🌸","hibiscus":"🌺","earth_americas":"🌎","earth_africa":"🌍","earth_asia":"🌏","full_moon":"🌕","waning_gibbous_moon":"🌖","last_quarter_moon":"🌗","waning_crescent_moon":"🌘","new_moon":"🌑","waxing_crescent_moon":"🌒","first_quarter_moon":"🌓","moon":"🌔","waxing_gibbous_moon":"🌔","new_moon_with_face":"🌚","full_moon_with_face":"🌝","sun_with_face":"🌞","first_quarter_moon_with_face":"🌛","last_quarter_moon_with_face":"🌜","crescent_moon":"🌙","dizzy":"💫","star":"⭐️","star2":"🌟","sparkles":"✨","zap":"⚡️","fire":"🔥","boom":"💥","collision":"💥","comet":"☄","sunny":"☀️","sun_behind_small_cloud":"🌤","partly_sunny":"⛅️","sun_behind_large_cloud":"🌥","sun_behind_rain_cloud":"🌦","rainbow":"🌈","cloud":"☁️","cloud_with_rain":"🌧","cloud_with_lightning_and_rain":"⛈","cloud_with_lightning":"🌩","cloud_with_snow":"🌨","snowman_with_snow":"☃️","snowman":"⛄️","snowflake":"❄️","wind_face":"🌬","dash":"💨","tornado":"🌪","fog":"🌫","ocean":"🌊","droplet":"💧","sweat_drops":"💦","umbrella":"☔️","green_apple":"🍏","apple":"🍎","pear":"🍐","tangerine":"🍊","orange":"🍊","mandarin":"🍊","lemon":"🍋","banana":"🍌","watermelon":"🍉","grapes":"🍇","strawberry":"🍓","melon":"🍈","cherries":"🍒","peach":"🍑","pineapple":"🍍","kiwi_fruit":"🥝","avocado":"🥑","tomato":"🍅","eggplant":"🍆","cucumber":"🥒","carrot":"🥕","corn":"🌽","hot_pepper":"🌶","potato":"🥔","sweet_potato":"🍠","chestnut":"🌰","peanuts":"🥜","honey_pot":"🍯","croissant":"🥐","bread":"🍞","baguette_bread":"🥖","cheese":"🧀","egg":"🥚","fried_egg":"🍳","bacon":"🥓","pancakes":"🥞","fried_shrimp":"🍤","poultry_leg":"🍗","meat_on_bone":"🍖","pizza":"🍕","hotdog":"🌭","hamburger":"🍔","fries":"🍟","stuffed_flatbread":"🥙","taco":"🌮","burrito":"🌯","green_salad":"🥗","shallow_pan_of_food":"🥘","spaghetti":"🍝","ramen":"🍜","stew":"🍲","fish_cake":"🍥","sushi":"🍣","bento":"🍱","curry":"🍛","rice":"🍚","rice_ball":"🍙","rice_cracker":"🍘","oden":"🍢","dango":"🍡","shaved_ice":"🍧","ice_cream":"🍨","icecream":"🍦","cake":"🍰","birthday":"🎂","custard":"🍮","lollipop":"🍭","candy":"🍬","chocolate_bar":"🍫","popcorn":"🍿","doughnut":"🍩","cookie":"🍪","milk_glass":"🥛","baby_bottle":"🍼","coffee":"☕️","tea":"🍵","sake":"🍶","beer":"🍺","beers":"🍻","clinking_glasses":"🥂","wine_glass":"🍷","tumbler_glass":"🥃","cocktail":"🍸","tropical_drink":"🍹","champagne":"🍾","spoon":"🥄","fork_and_knife":"🍴","plate_with_cutlery":"🍽","soccer":"⚽️","basketball":"🏀","football":"🏈","baseball":"⚾️","tennis":"🎾","volleyball":"🏐","rugby_football":"🏉","8ball":"🎱","ping_pong":"🏓","badminton":"🏸","goal_net":"🥅","ice_hockey":"🏒","field_hockey":"🏑","cricket":"🏏","golf":"⛳️","bow_and_arrow":"🏹","fishing_pole_and_fish":"🎣","boxing_glove":"🥊","martial_arts_uniform":"🥋","ice_skate":"⛸","ski":"🎿","skier":"⛷","snowboarder":"🏂","weight_lifting_woman":"🏋️‍♀️","weight_lifting_man":"🏋","person_fencing":"🤺","women_wrestling":"🤼‍♀","men_wrestling":"🤼‍♂","woman_cartwheeling":"🤸‍♀","man_cartwheeling":"🤸‍♂","basketball_woman":"⛹️‍♀️","basketball_man":"⛹","woman_playing_handball":"🤾‍♀","man_playing_handball":"🤾‍♂","golfing_woman":"🏌️‍♀️","golfing_man":"🏌","surfing_woman":"🏄‍♀","surfing_man":"🏄","surfer":"🏄","swimming_woman":"🏊‍♀","swimming_man":"🏊","swimmer":"🏊","woman_playing_water_polo":"🤽‍♀","man_playing_water_polo":"🤽‍♂","rowing_woman":"🚣‍♀","rowing_man":"🚣","rowboat":"🚣","horse_racing":"🏇","biking_woman":"🚴‍♀","biking_man":"🚴","bicyclist":"🚴","mountain_biking_woman":"🚵‍♀","mountain_biking_man":"🚵","mountain_bicyclist":"🚵","running_shirt_with_sash":"🎽","medal_sports":"🏅","medal_military":"🎖","1st_place_medal":"🥇","2nd_place_medal":"🥈","3rd_place_medal":"🥉","trophy":"🏆","rosette":"🏵","reminder_ribbon":"🎗","ticket":"🎫","tickets":"🎟","circus_tent":"🎪","woman_juggling":"🤹‍♀","man_juggling":"🤹‍♂","performing_arts":"🎭","art":"🎨","clapper":"🎬","microphone":"🎤","headphones":"🎧","musical_score":"🎼","musical_keyboard":"🎹","drum":"🥁","saxophone":"🎷","trumpet":"🎺","guitar":"🎸","violin":"🎻","game_die":"🎲","dart":"🎯","bowling":"🎳","video_game":"🎮","slot_machine":"🎰","car":"🚗","red_car":"🚗","taxi":"🚕","blue_car":"🚙","bus":"🚌","trolleybus":"🚎","racing_car":"🏎","police_car":"🚓","ambulance":"🚑","fire_engine":"🚒","minibus":"🚐","truck":"🚚","articulated_lorry":"🚛","tractor":"🚜","kick_scooter":"🛴","bike":"🚲","motor_scooter":"🛵","motorcycle":"🏍","rotating_light":"🚨","oncoming_police_car":"🚔","oncoming_bus":"🚍","oncoming_automobile":"🚘","oncoming_taxi":"🚖","aerial_tramway":"🚡","mountain_cableway":"🚠","suspension_railway":"🚟","railway_car":"🚃","train":"🚋","mountain_railway":"🚞","monorail":"🚝","bullettrain_side":"🚄","bullettrain_front":"🚅","light_rail":"🚈","steam_locomotive":"🚂","train2":"🚆","metro":"🚇","tram":"🚊","station":"🚉","helicopter":"🚁","small_airplane":"🛩","airplane":"✈️","flight_departure":"🛫","flight_arrival":"🛬","rocket":"🚀","artificial_satellite":"🛰","seat":"💺","canoe":"🛶","boat":"⛵️","sailboat":"⛵️","motor_boat":"🛥","speedboat":"🚤","passenger_ship":"🛳","ferry":"⛴","ship":"🚢","anchor":"⚓️","construction":"🚧","fuelpump":"⛽️","busstop":"🚏","vertical_traffic_light":"🚦","traffic_light":"🚥","world_map":"🗺","moyai":"🗿","statue_of_liberty":"🗽","fountain":"⛲️","tokyo_tower":"🗼","european_castle":"🏰","japanese_castle":"🏯","stadium":"🏟","ferris_wheel":"🎡","roller_coaster":"🎢","carousel_horse":"🎠","parasol_on_ground":"⛱","beach_umbrella":"🏖","desert_island":"🏝","mountain":"⛰","mountain_snow":"🏔","mount_fuji":"🗻","volcano":"🌋","desert":"🏜","camping":"🏕","tent":"⛺️","railway_track":"🛤","motorway":"🛣","building_construction":"🏗","factory":"🏭","house":"🏠","house_with_garden":"🏡","houses":"🏘","derelict_house":"🏚","office":"🏢","department_store":"🏬","post_office":"🏣","european_post_office":"🏤","hospital":"🏥","bank":"🏦","hotel":"🏨","convenience_store":"🏪","school":"🏫","love_hotel":"🏩","wedding":"💒","classical_building":"🏛","church":"⛪️","mosque":"🕌","synagogue":"🕍","kaaba":"🕋","shinto_shrine":"⛩","japan":"🗾","rice_scene":"🎑","national_park":"🏞","sunrise":"🌅","sunrise_over_mountains":"🌄","stars":"🌠","sparkler":"🎇","fireworks":"🎆","city_sunrise":"🌇","city_sunset":"🌆","cityscape":"🏙","night_with_stars":"🌃","milky_way":"🌌","bridge_at_night":"🌉","foggy":"🌁","watch":"⌚️","iphone":"📱","calling":"📲","computer":"💻","keyboard":"⌨️","desktop_computer":"🖥","printer":"🖨","computer_mouse":"🖱","trackball":"🖲","joystick":"🕹","clamp":"🗜","minidisc":"💽","floppy_disk":"💾","cd":"💿","dvd":"📀","vhs":"📼","camera":"📷","camera_flash":"📸","video_camera":"📹","movie_camera":"🎥","film_projector":"📽","film_strip":"🎞","telephone_receiver":"📞","phone":"☎️","telephone":"☎️","pager":"📟","fax":"📠","tv":"📺","radio":"📻","studio_microphone":"🎙","level_slider":"🎚","control_knobs":"🎛","stopwatch":"⏱","timer_clock":"⏲","alarm_clock":"⏰","mantelpiece_clock":"🕰","hourglass":"⌛️","hourglass_flowing_sand":"⏳","satellite":"📡","battery":"🔋","electric_plug":"🔌","bulb":"💡","flashlight":"🔦","candle":"🕯","wastebasket":"🗑","oil_drum":"🛢","money_with_wings":"💸","dollar":"💵","yen":"💴","euro":"💶","pound":"💷","moneybag":"💰","credit_card":"💳","gem":"💎","balance_scale":"⚖️","wrench":"🔧","hammer":"🔨","hammer_and_pick":"⚒","hammer_and_wrench":"🛠","pick":"⛏","nut_and_bolt":"🔩","gear":"⚙️","chains":"⛓","gun":"🔫","bomb":"💣","hocho":"🔪","knife":"🔪","dagger":"🗡","crossed_swords":"⚔️","shield":"🛡","smoking":"🚬","coffin":"⚰️","funeral_urn":"⚱️","amphora":"🏺","crystal_ball":"🔮","prayer_beads":"📿","barber":"💈","alembic":"⚗️","telescope":"🔭","microscope":"🔬","hole":"🕳","pill":"💊","syringe":"💉","thermometer":"🌡","toilet":"🚽","potable_water":"🚰","shower":"🚿","bathtub":"🛁","bath":"🛀","bellhop_bell":"🛎","key":"🔑","old_key":"🗝","door":"🚪","couch_and_lamp":"🛋","bed":"🛏","sleeping_bed":"🛌","framed_picture":"🖼","shopping":"🛍","shopping_cart":"🛒","gift":"🎁","balloon":"🎈","flags":"🎏","ribbon":"🎀","confetti_ball":"🎊","tada":"🎉","dolls":"🎎","izakaya_lantern":"🏮","lantern":"🏮","wind_chime":"🎐","email":"✉️","envelope":"✉️","envelope_with_arrow":"📩","incoming_envelope":"📨","e-mail":"📧","love_letter":"💌","inbox_tray":"📥","outbox_tray":"📤","package":"📦","label":"🏷","mailbox_closed":"📪","mailbox":"📫","mailbox_with_mail":"📬","mailbox_with_no_mail":"📭","postbox":"📮","postal_horn":"📯","scroll":"📜","page_with_curl":"📃","page_facing_up":"📄","bookmark_tabs":"📑","bar_chart":"📊","chart_with_upwards_trend":"📈","chart_with_downwards_trend":"📉","spiral_notepad":"🗒","spiral_calendar":"🗓","calendar":"📆","date":"📅","card_index":"📇","card_file_box":"🗃","ballot_box":"🗳","file_cabinet":"🗄","clipboard":"📋","file_folder":"📁","open_file_folder":"📂","card_index_dividers":"🗂","newspaper_roll":"🗞","newspaper":"📰","notebook":"📓","notebook_with_decorative_cover":"📔","ledger":"📒","closed_book":"📕","green_book":"📗","blue_book":"📘","orange_book":"📙","books":"📚","book":"📖","open_book":"📖","bookmark":"🔖","link":"🔗","paperclip":"📎","paperclips":"🖇","triangular_ruler":"📐","straight_ruler":"📏","pushpin":"📌","round_pushpin":"📍","scissors":"✂️","pen":"🖊","fountain_pen":"🖋","black_nib":"✒️","paintbrush":"🖌","crayon":"🖍","memo":"📝","pencil":"📝","pencil2":"✏️","mag":"🔍","mag_right":"🔎","lock_with_ink_pen":"🔏","closed_lock_with_key":"🔐","lock":"🔒","unlock":"🔓","heart":"❤️","yellow_heart":"💛","green_heart":"💚","blue_heart":"💙","purple_heart":"💜","black_heart":"🖤","broken_heart":"💔","heavy_heart_exclamation":"❣️","two_hearts":"💕","revolving_hearts":"💞","heartbeat":"💓","heartpulse":"💗","sparkling_heart":"💖","cupid":"💘","gift_heart":"💝","heart_decoration":"💟","peace_symbol":"☮️","latin_cross":"✝️","star_and_crescent":"☪️","om":"🕉","wheel_of_dharma":"☸️","star_of_david":"✡️","six_pointed_star":"🔯","menorah":"🕎","yin_yang":"☯️","orthodox_cross":"☦️","place_of_worship":"🛐","ophiuchus":"⛎","aries":"♈️","taurus":"♉️","gemini":"♊️","cancer":"♋️","leo":"♌️","virgo":"♍️","libra":"♎️","scorpius":"♏️","sagittarius":"♐️","capricorn":"♑️","aquarius":"♒️","pisces":"♓️","id":"🆔","atom_symbol":"⚛️","accept":"🉑","radioactive":"☢️","biohazard":"☣️","mobile_phone_off":"📴","vibration_mode":"📳","eight_pointed_black_star":"✴️","vs":"🆚","white_flower":"💮","ideograph_advantage":"🉐","secret":"㊙️","congratulations":"㊗️","u6e80":"🈵","a":"🅰️","b":"🅱️","ab":"🆎","cl":"🆑","o2":"🅾️","sos":"🆘","x":"❌","o":"⭕️","stop_sign":"🛑","no_entry":"⛔️","name_badge":"📛","no_entry_sign":"🚫","anger":"💢","hotsprings":"♨️","no_pedestrians":"🚷","do_not_litter":"🚯","no_bicycles":"🚳","non-potable_water":"🚱","underage":"🔞","no_mobile_phones":"📵","no_smoking":"🚭","exclamation":"❗️","heavy_exclamation_mark":"❗️","grey_exclamation":"❕","question":"❓","grey_question":"❔","bangbang":"‼️","interrobang":"⁉️","low_brightness":"🔅","high_brightness":"🔆","part_alternation_mark":"〽️","warning":"⚠️","children_crossing":"🚸","trident":"🔱","fleur_de_lis":"⚜️","beginner":"🔰","recycle":"♻️","white_check_mark":"✅","chart":"💹","sparkle":"❇️","eight_spoked_asterisk":"✳️","negative_squared_cross_mark":"❎","globe_with_meridians":"🌐","diamond_shape_with_a_dot_inside":"💠","m":"Ⓜ️","cyclone":"🌀","zzz":"💤","atm":"🏧","wc":"🚾","wheelchair":"♿️","parking":"🅿️","sa":"🈂️","passport_control":"🛂","customs":"🛃","baggage_claim":"🛄","left_luggage":"🛅","mens":"🚹","womens":"🚺","baby_symbol":"🚼","restroom":"🚻","put_litter_in_its_place":"🚮","cinema":"🎦","signal_strength":"📶","koko":"🈁","symbols":"🔣","information_source":"ℹ️","abc":"🔤","abcd":"🔡","capital_abcd":"🔠","ng":"🆖","ok":"🆗","up":"🆙","cool":"🆒","new":"🆕","free":"🆓","zero":"0️⃣","one":"1️⃣","two":"2️⃣","three":"3️⃣","four":"4️⃣","five":"5️⃣","six":"6️⃣","seven":"7️⃣","eight":"8️⃣","nine":"9️⃣","keycap_ten":"🔟","hash":"#️⃣","asterisk":"*️⃣","arrow_forward":"▶️","pause_button":"⏸","play_or_pause_button":"⏯","stop_button":"⏹","record_button":"⏺","next_track_button":"⏭","previous_track_button":"⏮","fast_forward":"⏩","rewind":"⏪","arrow_double_up":"⏫","arrow_double_down":"⏬","arrow_backward":"◀️","arrow_up_small":"🔼","arrow_down_small":"🔽","arrow_right":"➡️","arrow_left":"⬅️","arrow_up":"⬆️","arrow_down":"⬇️","arrow_upper_right":"↗️","arrow_lower_right":"↘️","arrow_lower_left":"↙️","arrow_upper_left":"↖️","arrow_up_down":"↕️","left_right_arrow":"↔️","arrow_right_hook":"↪️","leftwards_arrow_with_hook":"↩️","arrow_heading_up":"⤴️","arrow_heading_down":"⤵️","twisted_rightwards_arrows":"🔀","repeat":"🔁","repeat_one":"🔂","arrows_counterclockwise":"🔄","arrows_clockwise":"🔃","musical_note":"🎵","notes":"🎶","heavy_plus_sign":"➕","heavy_minus_sign":"➖","heavy_division_sign":"➗","heavy_multiplication_x":"✖️","heavy_dollar_sign":"💲","currency_exchange":"💱","tm":"™️","copyright":"©️","registered":"®️","wavy_dash":"〰️","curly_loop":"➰","loop":"➿","end":"🔚","back":"🔙","on":"🔛","top":"🔝","soon":"🔜","heavy_check_mark":"✔️","ballot_box_with_check":"☑️","radio_button":"🔘","white_circle":"⚪️","black_circle":"⚫️","red_circle":"🔴","large_blue_circle":"🔵","small_red_triangle":"🔺","small_red_triangle_down":"🔻","small_orange_diamond":"🔸","small_blue_diamond":"🔹","large_orange_diamond":"🔶","large_blue_diamond":"🔷","white_square_button":"🔳","black_square_button":"🔲","black_small_square":"▪️","white_small_square":"▫️","black_medium_small_square":"◾️","white_medium_small_square":"◽️","black_medium_square":"◼️","white_medium_square":"◻️","black_large_square":"⬛️","white_large_square":"⬜️","speaker":"🔈","mute":"🔇","sound":"🔉","loud_sound":"🔊","bell":"🔔","no_bell":"🔕","mega":"📣","loudspeaker":"📢","eye_speech_bubble":"👁‍🗨","speech_balloon":"💬","thought_balloon":"💭","right_anger_bubble":"🗯","spades":"♠️","clubs":"♣️","hearts":"♥️","diamonds":"♦️","black_joker":"🃏","flower_playing_cards":"🎴","mahjong":"🀄️","clock1":"🕐","clock2":"🕑","clock3":"🕒","clock4":"🕓","clock5":"🕔","clock6":"🕕","clock7":"🕖","clock8":"🕗","clock9":"🕘","clock10":"🕙","clock11":"🕚","clock12":"🕛","clock130":"🕜","clock230":"🕝","clock330":"🕞","clock430":"🕟","clock530":"🕠","clock630":"🕡","clock730":"🕢","clock830":"🕣","clock930":"🕤","clock1030":"🕥","clock1130":"🕦","clock1230":"🕧","white_flag":"🏳️","black_flag":"🏴","checkered_flag":"🏁","triangular_flag_on_post":"🚩","rainbow_flag":"🏳️‍🌈","afghanistan":"🇦🇫","aland_islands":"🇦🇽","albania":"🇦🇱","algeria":"🇩🇿","american_samoa":"🇦🇸","andorra":"🇦🇩","angola":"🇦🇴","anguilla":"🇦🇮","antarctica":"🇦🇶","antigua_barbuda":"🇦🇬","argentina":"🇦🇷","armenia":"🇦🇲","aruba":"🇦🇼","australia":"🇦🇺","austria":"🇦🇹","azerbaijan":"🇦🇿","bahamas":"🇧🇸","bahrain":"🇧🇭","bangladesh":"🇧🇩","barbados":"🇧🇧","belarus":"🇧🇾","belgium":"🇧🇪","belize":"🇧🇿","benin":"🇧🇯","bermuda":"🇧🇲","bhutan":"🇧🇹","bolivia":"🇧🇴","caribbean_netherlands":"🇧🇶","bosnia_herzegovina":"🇧🇦","botswana":"🇧🇼","brazil":"🇧🇷","british_indian_ocean_territory":"🇮🇴","british_virgin_islands":"🇻🇬","brunei":"🇧🇳","bulgaria":"🇧🇬","burkina_faso":"🇧🇫","burundi":"🇧🇮","cape_verde":"🇨🇻","cambodia":"🇰🇭","cameroon":"🇨🇲","canada":"🇨🇦","canary_islands":"🇮🇨","cayman_islands":"🇰🇾","central_african_republic":"🇨🇫","chad":"🇹🇩","chile":"🇨🇱","cn":"🇨🇳","christmas_island":"🇨🇽","cocos_islands":"🇨🇨","colombia":"🇨🇴","comoros":"🇰🇲","congo_brazzaville":"🇨🇬","congo_kinshasa":"🇨🇩","cook_islands":"🇨🇰","costa_rica":"🇨🇷","cote_divoire":"🇨🇮","croatia":"🇭🇷","cuba":"🇨🇺","curacao":"🇨🇼","cyprus":"🇨🇾","czech_republic":"🇨🇿","denmark":"🇩🇰","djibouti":"🇩🇯","dominica":"🇩🇲","dominican_republic":"🇩🇴","ecuador":"🇪🇨","egypt":"🇪🇬","el_salvador":"🇸🇻","equatorial_guinea":"🇬🇶","eritrea":"🇪🇷","estonia":"🇪🇪","ethiopia":"🇪🇹","eu":"🇪🇺","european_union":"🇪🇺","falkland_islands":"🇫🇰","faroe_islands":"🇫🇴","fiji":"🇫🇯","finland":"🇫🇮","fr":"🇫🇷","french_guiana":"🇬🇫","french_polynesia":"🇵🇫","french_southern_territories":"🇹🇫","gabon":"🇬🇦","gambia":"🇬🇲","georgia":"🇬🇪","de":"🇩🇪","ghana":"🇬🇭","gibraltar":"🇬🇮","greece":"🇬🇷","greenland":"🇬🇱","grenada":"🇬🇩","guadeloupe":"🇬🇵","guam":"🇬🇺","guatemala":"🇬🇹","guernsey":"🇬🇬","guinea":"🇬🇳","guinea_bissau":"🇬🇼","guyana":"🇬🇾","haiti":"🇭🇹","honduras":"🇭🇳","hong_kong":"🇭🇰","hungary":"🇭🇺","iceland":"🇮🇸","india":"🇮🇳","indonesia":"🇮🇩","iran":"🇮🇷","iraq":"🇮🇶","ireland":"🇮🇪","isle_of_man":"🇮🇲","israel":"🇮🇱","it":"🇮🇹","jamaica":"🇯🇲","jp":"🇯🇵","crossed_flags":"🎌","jersey":"🇯🇪","jordan":"🇯🇴","kazakhstan":"🇰🇿","kenya":"🇰🇪","kiribati":"🇰🇮","kosovo":"🇽🇰","kuwait":"🇰🇼","kyrgyzstan":"🇰🇬","laos":"🇱🇦","latvia":"🇱🇻","lebanon":"🇱🇧","lesotho":"🇱🇸","liberia":"🇱🇷","libya":"🇱🇾","liechtenstein":"🇱🇮","lithuania":"🇱🇹","luxembourg":"🇱🇺","macau":"🇲🇴","macedonia":"🇲🇰","madagascar":"🇲🇬","malawi":"🇲🇼","malaysia":"🇲🇾","maldives":"🇲🇻","mali":"🇲🇱","malta":"🇲🇹","marshall_islands":"🇲🇭","martinique":"🇲🇶","mauritania":"🇲🇷","mauritius":"🇲🇺","mayotte":"🇾🇹","mexico":"🇲🇽","micronesia":"🇫🇲","moldova":"🇲🇩","monaco":"🇲🇨","mongolia":"🇲🇳","montenegro":"🇲🇪","montserrat":"🇲🇸","morocco":"🇲🇦","mozambique":"🇲🇿","myanmar":"🇲🇲","namibia":"🇳🇦","nauru":"🇳🇷","nepal":"🇳🇵","netherlands":"🇳🇱","new_caledonia":"🇳🇨","new_zealand":"🇳🇿","nicaragua":"🇳🇮","niger":"🇳🇪","nigeria":"🇳🇬","niue":"🇳🇺","norfolk_island":"🇳🇫","northern_mariana_islands":"🇲🇵","north_korea":"🇰🇵","norway":"🇳🇴","oman":"🇴🇲","pakistan":"🇵🇰","palau":"🇵🇼","palestinian_territories":"🇵🇸","panama":"🇵🇦","papua_new_guinea":"🇵🇬","paraguay":"🇵🇾","peru":"🇵🇪","philippines":"🇵🇭","pitcairn_islands":"🇵🇳","poland":"🇵🇱","portugal":"🇵🇹","puerto_rico":"🇵🇷","qatar":"🇶🇦","reunion":"🇷🇪","romania":"🇷🇴","ru":"🇷🇺","rwanda":"🇷🇼","st_barthelemy":"🇧🇱","st_helena":"🇸🇭","st_kitts_nevis":"🇰🇳","st_lucia":"🇱🇨","st_pierre_miquelon":"🇵🇲","st_vincent_grenadines":"🇻🇨","samoa":"🇼🇸","san_marino":"🇸🇲","sao_tome_principe":"🇸🇹","saudi_arabia":"🇸🇦","senegal":"🇸🇳","serbia":"🇷🇸","seychelles":"🇸🇨","sierra_leone":"🇸🇱","singapore":"🇸🇬","sint_maarten":"🇸🇽","slovakia":"🇸🇰","slovenia":"🇸🇮","solomon_islands":"🇸🇧","somalia":"🇸🇴","south_africa":"🇿🇦","south_georgia_south_sandwich_islands":"🇬🇸","kr":"🇰🇷","south_sudan":"🇸🇸","es":"🇪🇸","sri_lanka":"🇱🇰","sudan":"🇸🇩","suriname":"🇸🇷","swaziland":"🇸🇿","sweden":"🇸🇪","switzerland":"🇨🇭","syria":"🇸🇾","taiwan":"🇹🇼","tajikistan":"🇹🇯","tanzania":"🇹🇿","thailand":"🇹🇭","timor_leste":"🇹🇱","togo":"🇹🇬","tokelau":"🇹🇰","tonga":"🇹🇴","trinidad_tobago":"🇹🇹","tunisia":"🇹🇳","tr":"🇹🇷","turkmenistan":"🇹🇲","turks_caicos_islands":"🇹🇨","tuvalu":"🇹🇻","uganda":"🇺🇬","ukraine":"🇺🇦","united_arab_emirates":"🇦🇪","gb":"🇬🇧","uk":"🇬🇧","us":"🇺🇸","us_virgin_islands":"🇻🇮","uruguay":"🇺🇾","uzbekistan":"🇺🇿","vanuatu":"🇻🇺","vatican_city":"🇻🇦","venezuela":"🇻🇪","vietnam":"🇻🇳","wallis_futuna":"🇼🇫","western_sahara":"🇪🇭","yemen":"🇾🇪","zambia":"🇿🇲","zimbabwe":"🇿🇼"}
 
 /***/ }),
-/* 125 */
+/* 129 */
 /***/ (function(module, exports) {
 
 	// Emoticons -> Emoji mapping.
@@ -9293,7 +9336,7 @@ return /******/ (function(modules) { // webpackBootstrap
 
 
 /***/ }),
-/* 126 */
+/* 130 */
 /***/ (function(module, exports) {
 
 	'use strict';
@@ -9304,7 +9347,7 @@ return /******/ (function(modules) { // webpackBootstrap
 
 
 /***/ }),
-/* 127 */
+/* 131 */
 /***/ (function(module, exports) {
 
 	// Emojies & shortcuts replacement logic.
@@ -9399,7 +9442,7 @@ return /******/ (function(modules) { // webpackBootstrap
 
 
 /***/ }),
-/* 128 */
+/* 132 */
 /***/ (function(module, exports) {
 
 	// Convert input options to more useable format
@@ -9464,7 +9507,7 @@ return /******/ (function(modules) { // webpackBootstrap
 
 
 /***/ }),
-/* 129 */
+/* 133 */
 /***/ (function(module, exports) {
 
 	// Process ~subscript~
@@ -9536,7 +9579,7 @@ return /******/ (function(modules) { // webpackBootstrap
 
 
 /***/ }),
-/* 130 */
+/* 134 */
 /***/ (function(module, exports) {
 
 	// Process ^superscript^
@@ -9607,7 +9650,7 @@ return /******/ (function(modules) { // webpackBootstrap
 
 
 /***/ }),
-/* 131 */
+/* 135 */
 /***/ (function(module, exports) {
 
 	// Process footnotes
@@ -9939,7 +9982,7 @@ return /******/ (function(modules) { // webpackBootstrap
 
 
 /***/ }),
-/* 132 */
+/* 136 */
 /***/ (function(module, exports) {
 
 	// Process definition lists
@@ -10173,7 +10216,7 @@ return /******/ (function(modules) { // webpackBootstrap
 
 
 /***/ }),
-/* 133 */
+/* 137 */
 /***/ (function(module, exports) {
 
 	// Enclose abbreviations in <abbr> tags
@@ -10327,7 +10370,7 @@ return /******/ (function(modules) { // webpackBootstrap
 
 
 /***/ }),
-/* 134 */
+/* 138 */
 /***/ (function(module, exports) {
 
 	'use strict';
@@ -10453,7 +10496,7 @@ return /******/ (function(modules) { // webpackBootstrap
 
 
 /***/ }),
-/* 135 */
+/* 139 */
 /***/ (function(module, exports) {
 
 	'use strict';
@@ -10579,7 +10622,7 @@ return /******/ (function(modules) { // webpackBootstrap
 
 
 /***/ }),
-/* 136 */
+/* 140 */
 /***/ (function(module, exports, __webpack_require__) {
 
 	"use strict";
@@ -10774,11 +10817,11 @@ return /******/ (function(modules) { // webpackBootstrap
 	  }
 	};
 
-	var _clone = __webpack_require__(137);
+	var _clone = __webpack_require__(141);
 
 	var _clone2 = _interopRequireDefault(_clone);
 
-	var _uslug = __webpack_require__(142);
+	var _uslug = __webpack_require__(146);
 
 	var _uslug2 = _interopRequireDefault(_uslug);
 
@@ -10892,7 +10935,7 @@ return /******/ (function(modules) { // webpackBootstrap
 	};
 
 /***/ }),
-/* 137 */
+/* 141 */
 /***/ (function(module, exports, __webpack_require__) {
 
 	/* WEBPACK VAR INJECTION */(function(Buffer) {var clone = (function() {
@@ -11147,10 +11190,10 @@ return /******/ (function(modules) { // webpackBootstrap
 	  module.exports = clone;
 	}
 
-	/* WEBPACK VAR INJECTION */}.call(exports, __webpack_require__(138).Buffer))
+	/* WEBPACK VAR INJECTION */}.call(exports, __webpack_require__(142).Buffer))
 
 /***/ }),
-/* 138 */
+/* 142 */
 /***/ (function(module, exports, __webpack_require__) {
 
 	/* WEBPACK VAR INJECTION */(function(global) {/*!
@@ -11163,9 +11206,9 @@ return /******/ (function(modules) { // webpackBootstrap
 
 	'use strict'
 
-	var base64 = __webpack_require__(139)
-	var ieee754 = __webpack_require__(140)
-	var isArray = __webpack_require__(141)
+	var base64 = __webpack_require__(143)
+	var ieee754 = __webpack_require__(144)
+	var isArray = __webpack_require__(145)
 
 	exports.Buffer = Buffer
 	exports.SlowBuffer = SlowBuffer
@@ -12946,7 +12989,7 @@ return /******/ (function(modules) { // webpackBootstrap
 	/* WEBPACK VAR INJECTION */}.call(exports, (function() { return this; }())))
 
 /***/ }),
-/* 139 */
+/* 143 */
 /***/ (function(module, exports) {
 
 	'use strict'
@@ -13066,7 +13109,7 @@ return /******/ (function(modules) { // webpackBootstrap
 
 
 /***/ }),
-/* 140 */
+/* 144 */
 /***/ (function(module, exports) {
 
 	exports.read = function (buffer, offset, isLE, mLen, nBytes) {
@@ -13156,7 +13199,7 @@ return /******/ (function(modules) { // webpackBootstrap
 
 
 /***/ }),
-/* 141 */
+/* 145 */
 /***/ (function(module, exports) {
 
 	var toString = {}.toString;
@@ -13167,21 +13210,21 @@ return /******/ (function(modules) { // webpackBootstrap
 
 
 /***/ }),
-/* 142 */
+/* 146 */
 /***/ (function(module, exports, __webpack_require__) {
 
-	module.exports = __webpack_require__(143);
+	module.exports = __webpack_require__(147);
 
 /***/ }),
-/* 143 */
+/* 147 */
 /***/ (function(module, exports, __webpack_require__) {
 
 	(function() {
-	  var L = __webpack_require__(144).L,
-	      N = __webpack_require__(145).N,
-	      Z = __webpack_require__(146).Z,
-	      M = __webpack_require__(147).M,
-	      unorm = __webpack_require__(148);
+	  var L = __webpack_require__(148).L,
+	      N = __webpack_require__(149).N,
+	      Z = __webpack_require__(150).Z,
+	      M = __webpack_require__(151).M,
+	      unorm = __webpack_require__(152);
 
 	  var _unicodeCategory = function(code) {
 	    if (~L.indexOf(code)) return 'L';
@@ -13236,7 +13279,7 @@ return /******/ (function(modules) { // webpackBootstrap
 	}());
 
 /***/ }),
-/* 144 */
+/* 148 */
 /***/ (function(module, exports) {
 
 	/* 
@@ -13257,7 +13300,7 @@ return /******/ (function(modules) { // webpackBootstrap
 
 
 /***/ }),
-/* 145 */
+/* 149 */
 /***/ (function(module, exports) {
 
 	/*
@@ -13276,7 +13319,7 @@ return /******/ (function(modules) { // webpackBootstrap
 
 
 /***/ }),
-/* 146 */
+/* 150 */
 /***/ (function(module, exports) {
 
 	/*
@@ -13295,7 +13338,7 @@ return /******/ (function(modules) { // webpackBootstrap
 
 
 /***/ }),
-/* 147 */
+/* 151 */
 /***/ (function(module, exports) {
 
 	/*
@@ -13314,7 +13357,7 @@ return /******/ (function(modules) { // webpackBootstrap
 
 
 /***/ }),
-/* 148 */
+/* 152 */
 /***/ (function(module, exports, __webpack_require__) {
 
 	(function (root) {
@@ -13762,7 +13805,7 @@ return /******/ (function(modules) { // webpackBootstrap
 
 
 /***/ }),
-/* 149 */
+/* 153 */
 /***/ (function(module, exports, __webpack_require__) {
 
 	/* Process inline math */
@@ -13777,7 +13820,7 @@ return /******/ (function(modules) { // webpackBootstrap
 	/*jslint node: true */
 	'use strict';
 
-	var katex = __webpack_require__(150);
+	var katex = __webpack_require__(154);
 
 	// Test if potential opening or closing delimieter
 	// Assumes that there is a "$" at state.src[pos]
@@ -13965,7 +14008,7 @@ return /******/ (function(modules) { // webpackBootstrap
 
 
 /***/ }),
-/* 150 */
+/* 154 */
 /***/ (function(module, exports, __webpack_require__) {
 
 	/* eslint no-console:0 */
@@ -13977,12 +14020,12 @@ return /******/ (function(modules) { // webpackBootstrap
 	 * errors in the expression, or errors in javascript handling.
 	 */
 
-	var ParseError = __webpack_require__(151);
-	var Settings = __webpack_require__(152);
+	var ParseError = __webpack_require__(155);
+	var Settings = __webpack_require__(156);
 
-	var buildTree = __webpack_require__(153);
-	var parseTree = __webpack_require__(166);
-	var utils = __webpack_require__(158);
+	var buildTree = __webpack_require__(157);
+	var parseTree = __webpack_require__(170);
+	var utils = __webpack_require__(162);
 
 	/**
 	 * Parse and build an expression, and place that expression in the DOM node
@@ -14045,7 +14088,7 @@ return /******/ (function(modules) { // webpackBootstrap
 
 
 /***/ }),
-/* 151 */
+/* 155 */
 /***/ (function(module, exports) {
 
 	/**
@@ -14091,7 +14134,7 @@ return /******/ (function(modules) { // webpackBootstrap
 
 
 /***/ }),
-/* 152 */
+/* 156 */
 /***/ (function(module, exports) {
 
 	/**
@@ -14125,15 +14168,15 @@ return /******/ (function(modules) { // webpackBootstrap
 
 
 /***/ }),
-/* 153 */
+/* 157 */
 /***/ (function(module, exports, __webpack_require__) {
 
-	var buildHTML = __webpack_require__(154);
-	var buildMathML = __webpack_require__(163);
-	var buildCommon = __webpack_require__(156);
-	var Options = __webpack_require__(165);
-	var Settings = __webpack_require__(152);
-	var Style = __webpack_require__(155);
+	var buildHTML = __webpack_require__(158);
+	var buildMathML = __webpack_require__(167);
+	var buildCommon = __webpack_require__(160);
+	var Options = __webpack_require__(169);
+	var Settings = __webpack_require__(156);
+	var Style = __webpack_require__(159);
 
 	var makeSpan = buildCommon.makeSpan;
 
@@ -14171,7 +14214,7 @@ return /******/ (function(modules) { // webpackBootstrap
 
 
 /***/ }),
-/* 154 */
+/* 158 */
 /***/ (function(module, exports, __webpack_require__) {
 
 	/* eslint no-console:0 */
@@ -14182,14 +14225,14 @@ return /******/ (function(modules) { // webpackBootstrap
 	 * called, to produce a final HTML tree.
 	 */
 
-	var ParseError = __webpack_require__(151);
-	var Style = __webpack_require__(155);
+	var ParseError = __webpack_require__(155);
+	var Style = __webpack_require__(159);
 
-	var buildCommon = __webpack_require__(156);
-	var delimiter = __webpack_require__(162);
-	var domTree = __webpack_require__(157);
-	var fontMetrics = __webpack_require__(159);
-	var utils = __webpack_require__(158);
+	var buildCommon = __webpack_require__(160);
+	var delimiter = __webpack_require__(166);
+	var domTree = __webpack_require__(161);
+	var fontMetrics = __webpack_require__(163);
+	var utils = __webpack_require__(162);
 
 	var makeSpan = buildCommon.makeSpan;
 
@@ -15579,7 +15622,7 @@ return /******/ (function(modules) { // webpackBootstrap
 
 
 /***/ }),
-/* 155 */
+/* 159 */
 /***/ (function(module, exports) {
 
 	/**
@@ -15711,7 +15754,7 @@ return /******/ (function(modules) { // webpackBootstrap
 
 
 /***/ }),
-/* 156 */
+/* 160 */
 /***/ (function(module, exports, __webpack_require__) {
 
 	/* eslint no-console:0 */
@@ -15720,10 +15763,10 @@ return /******/ (function(modules) { // webpackBootstrap
 	 * different kinds of domTree nodes in a consistent manner.
 	 */
 
-	var domTree = __webpack_require__(157);
-	var fontMetrics = __webpack_require__(159);
-	var symbols = __webpack_require__(161);
-	var utils = __webpack_require__(158);
+	var domTree = __webpack_require__(161);
+	var fontMetrics = __webpack_require__(163);
+	var symbols = __webpack_require__(165);
+	var utils = __webpack_require__(162);
 
 	var greekCapitals = [
 	    "\\Gamma",
@@ -16167,7 +16210,7 @@ return /******/ (function(modules) { // webpackBootstrap
 
 
 /***/ }),
-/* 157 */
+/* 161 */
 /***/ (function(module, exports, __webpack_require__) {
 
 	/**
@@ -16180,7 +16223,7 @@ return /******/ (function(modules) { // webpackBootstrap
 	 * Similar functions for working with MathML nodes exist in mathMLTree.js.
 	 */
 
-	var utils = __webpack_require__(158);
+	var utils = __webpack_require__(162);
 
 	/**
 	 * Create an HTML className based on a list of classes. In addition to joining
@@ -16442,7 +16485,7 @@ return /******/ (function(modules) { // webpackBootstrap
 
 
 /***/ }),
-/* 158 */
+/* 162 */
 /***/ (function(module, exports) {
 
 	/**
@@ -16554,12 +16597,12 @@ return /******/ (function(modules) { // webpackBootstrap
 
 
 /***/ }),
-/* 159 */
+/* 163 */
 /***/ (function(module, exports, __webpack_require__) {
 
 	/* eslint no-unused-vars:0 */
 
-	var Style = __webpack_require__(155);
+	var Style = __webpack_require__(159);
 
 	/**
 	 * This file contains metrics regarding fonts and individual symbols. The sigma
@@ -16678,7 +16721,7 @@ return /******/ (function(modules) { // webpackBootstrap
 	// metrics, including height, depth, italic correction, and skew (kern from the
 	// character to the corresponding \skewchar)
 	// This map is generated via `make metrics`. It should not be changed manually.
-	var metricMap = __webpack_require__(160);
+	var metricMap = __webpack_require__(164);
 
 	/**
 	 * This function is a convenience function for looking up information in the
@@ -16707,7 +16750,7 @@ return /******/ (function(modules) { // webpackBootstrap
 
 
 /***/ }),
-/* 160 */
+/* 164 */
 /***/ (function(module, exports) {
 
 	module.exports = {
@@ -18465,7 +18508,7 @@ return /******/ (function(modules) { // webpackBootstrap
 
 
 /***/ }),
-/* 161 */
+/* 165 */
 /***/ (function(module, exports) {
 
 	/**
@@ -19091,7 +19134,7 @@ return /******/ (function(modules) { // webpackBootstrap
 
 
 /***/ }),
-/* 162 */
+/* 166 */
 /***/ (function(module, exports, __webpack_require__) {
 
 	/**
@@ -19116,13 +19159,13 @@ return /******/ (function(modules) { // webpackBootstrap
 	 * used in `\left` and `\right`.
 	 */
 
-	var ParseError = __webpack_require__(151);
-	var Style = __webpack_require__(155);
+	var ParseError = __webpack_require__(155);
+	var Style = __webpack_require__(159);
 
-	var buildCommon = __webpack_require__(156);
-	var fontMetrics = __webpack_require__(159);
-	var symbols = __webpack_require__(161);
-	var utils = __webpack_require__(158);
+	var buildCommon = __webpack_require__(160);
+	var fontMetrics = __webpack_require__(163);
+	var symbols = __webpack_require__(165);
+	var utils = __webpack_require__(162);
 
 	var makeSpan = buildCommon.makeSpan;
 
@@ -19639,7 +19682,7 @@ return /******/ (function(modules) { // webpackBootstrap
 
 
 /***/ }),
-/* 163 */
+/* 167 */
 /***/ (function(module, exports, __webpack_require__) {
 
 	/**
@@ -19648,12 +19691,12 @@ return /******/ (function(modules) { // webpackBootstrap
 	 * parser.
 	 */
 
-	var buildCommon = __webpack_require__(156);
-	var fontMetrics = __webpack_require__(159);
-	var mathMLTree = __webpack_require__(164);
-	var ParseError = __webpack_require__(151);
-	var symbols = __webpack_require__(161);
-	var utils = __webpack_require__(158);
+	var buildCommon = __webpack_require__(160);
+	var fontMetrics = __webpack_require__(163);
+	var mathMLTree = __webpack_require__(168);
+	var ParseError = __webpack_require__(155);
+	var symbols = __webpack_require__(165);
+	var utils = __webpack_require__(162);
 
 	var makeSpan = buildCommon.makeSpan;
 	var fontMap = buildCommon.fontMap;
@@ -20178,7 +20221,7 @@ return /******/ (function(modules) { // webpackBootstrap
 
 
 /***/ }),
-/* 164 */
+/* 168 */
 /***/ (function(module, exports, __webpack_require__) {
 
 	/**
@@ -20191,7 +20234,7 @@ return /******/ (function(modules) { // webpackBootstrap
 	 * domTree.js, creating namespaced DOM nodes and HTML text markup respectively.
 	 */
 
-	var utils = __webpack_require__(158);
+	var utils = __webpack_require__(162);
 
 	/**
 	 * This node represents a general purpose MathML node of any type. The
@@ -20286,7 +20329,7 @@ return /******/ (function(modules) { // webpackBootstrap
 
 
 /***/ }),
-/* 165 */
+/* 169 */
 /***/ (function(module, exports) {
 
 	/**
@@ -20481,7 +20524,7 @@ return /******/ (function(modules) { // webpackBootstrap
 
 
 /***/ }),
-/* 166 */
+/* 170 */
 /***/ (function(module, exports, __webpack_require__) {
 
 	/**
@@ -20489,7 +20532,7 @@ return /******/ (function(modules) { // webpackBootstrap
 	 * TODO(emily): Remove this
 	 */
 
-	var Parser = __webpack_require__(167);
+	var Parser = __webpack_require__(171);
 
 	/**
 	 * Parses an expression using a Parser, then returns the parsed result.
@@ -20504,18 +20547,18 @@ return /******/ (function(modules) { // webpackBootstrap
 
 
 /***/ }),
-/* 167 */
+/* 171 */
 /***/ (function(module, exports, __webpack_require__) {
 
 	/* eslint no-constant-condition:0 */
-	var functions = __webpack_require__(168);
-	var environments = __webpack_require__(169);
-	var Lexer = __webpack_require__(171);
-	var symbols = __webpack_require__(161);
-	var utils = __webpack_require__(158);
+	var functions = __webpack_require__(172);
+	var environments = __webpack_require__(173);
+	var Lexer = __webpack_require__(175);
+	var symbols = __webpack_require__(165);
+	var utils = __webpack_require__(162);
 
-	var parseData = __webpack_require__(170);
-	var ParseError = __webpack_require__(151);
+	var parseData = __webpack_require__(174);
+	var ParseError = __webpack_require__(155);
 
 	/**
 	 * This file contains the parser used to parse out a TeX expression from the
@@ -21247,11 +21290,11 @@ return /******/ (function(modules) { // webpackBootstrap
 
 
 /***/ }),
-/* 168 */
+/* 172 */
 /***/ (function(module, exports, __webpack_require__) {
 
-	var utils = __webpack_require__(158);
-	var ParseError = __webpack_require__(151);
+	var utils = __webpack_require__(162);
+	var ParseError = __webpack_require__(155);
 
 	/* This file contains a list of functions that we parse, identified by
 	 * the calls to defineFunction.
@@ -21833,13 +21876,13 @@ return /******/ (function(modules) { // webpackBootstrap
 
 
 /***/ }),
-/* 169 */
+/* 173 */
 /***/ (function(module, exports, __webpack_require__) {
 
 	/* eslint no-constant-condition:0 */
-	var fontMetrics = __webpack_require__(159);
-	var parseData = __webpack_require__(170);
-	var ParseError = __webpack_require__(151);
+	var fontMetrics = __webpack_require__(163);
+	var parseData = __webpack_require__(174);
+	var ParseError = __webpack_require__(155);
 
 	var ParseNode = parseData.ParseNode;
 
@@ -22060,7 +22103,7 @@ return /******/ (function(modules) { // webpackBootstrap
 
 
 /***/ }),
-/* 170 */
+/* 174 */
 /***/ (function(module, exports) {
 
 	/**
@@ -22079,7 +22122,7 @@ return /******/ (function(modules) { // webpackBootstrap
 
 
 /***/ }),
-/* 171 */
+/* 175 */
 /***/ (function(module, exports, __webpack_require__) {
 
 	/**
@@ -22095,9 +22138,9 @@ return /******/ (function(modules) { // webpackBootstrap
 	 * kinds.
 	 */
 
-	var matchAt = __webpack_require__(172);
+	var matchAt = __webpack_require__(176);
 
-	var ParseError = __webpack_require__(151);
+	var ParseError = __webpack_require__(155);
 
 	// The main lexer class
 	function Lexer(input) {
@@ -22247,7 +22290,7 @@ return /******/ (function(modules) { // webpackBootstrap
 
 
 /***/ }),
-/* 172 */
+/* 176 */
 /***/ (function(module, exports) {
 
 	/** @flow */
@@ -22294,10 +22337,10 @@ return /******/ (function(modules) { // webpackBootstrap
 	module.exports = matchAt;
 
 /***/ }),
-/* 173 */
+/* 177 */
 /***/ (function(module, exports, __webpack_require__) {
 
-	const hljs = __webpack_require__(174)
+	const hljs = __webpack_require__(178)
 
 	const maybe = f => {
 	  try {
@@ -22345,192 +22388,192 @@ return /******/ (function(modules) { // webpackBootstrap
 
 
 /***/ }),
-/* 174 */
+/* 178 */
 /***/ (function(module, exports, __webpack_require__) {
 
-	var hljs = __webpack_require__(175);
+	var hljs = __webpack_require__(179);
 
-	hljs.registerLanguage('1c', __webpack_require__(176));
-	hljs.registerLanguage('abnf', __webpack_require__(177));
-	hljs.registerLanguage('accesslog', __webpack_require__(178));
-	hljs.registerLanguage('actionscript', __webpack_require__(179));
-	hljs.registerLanguage('ada', __webpack_require__(180));
-	hljs.registerLanguage('apache', __webpack_require__(181));
-	hljs.registerLanguage('applescript', __webpack_require__(182));
-	hljs.registerLanguage('cpp', __webpack_require__(183));
-	hljs.registerLanguage('arduino', __webpack_require__(184));
-	hljs.registerLanguage('armasm', __webpack_require__(185));
-	hljs.registerLanguage('xml', __webpack_require__(186));
-	hljs.registerLanguage('asciidoc', __webpack_require__(187));
-	hljs.registerLanguage('aspectj', __webpack_require__(188));
-	hljs.registerLanguage('autohotkey', __webpack_require__(189));
-	hljs.registerLanguage('autoit', __webpack_require__(190));
-	hljs.registerLanguage('avrasm', __webpack_require__(191));
-	hljs.registerLanguage('awk', __webpack_require__(192));
-	hljs.registerLanguage('axapta', __webpack_require__(193));
-	hljs.registerLanguage('bash', __webpack_require__(194));
-	hljs.registerLanguage('basic', __webpack_require__(195));
-	hljs.registerLanguage('bnf', __webpack_require__(196));
-	hljs.registerLanguage('brainfuck', __webpack_require__(197));
-	hljs.registerLanguage('cal', __webpack_require__(198));
-	hljs.registerLanguage('capnproto', __webpack_require__(199));
-	hljs.registerLanguage('ceylon', __webpack_require__(200));
-	hljs.registerLanguage('clean', __webpack_require__(201));
-	hljs.registerLanguage('clojure', __webpack_require__(202));
-	hljs.registerLanguage('clojure-repl', __webpack_require__(203));
-	hljs.registerLanguage('cmake', __webpack_require__(204));
-	hljs.registerLanguage('coffeescript', __webpack_require__(205));
-	hljs.registerLanguage('coq', __webpack_require__(206));
-	hljs.registerLanguage('cos', __webpack_require__(207));
-	hljs.registerLanguage('crmsh', __webpack_require__(208));
-	hljs.registerLanguage('crystal', __webpack_require__(209));
-	hljs.registerLanguage('cs', __webpack_require__(210));
-	hljs.registerLanguage('csp', __webpack_require__(211));
-	hljs.registerLanguage('css', __webpack_require__(212));
-	hljs.registerLanguage('d', __webpack_require__(213));
-	hljs.registerLanguage('markdown', __webpack_require__(214));
-	hljs.registerLanguage('dart', __webpack_require__(215));
-	hljs.registerLanguage('delphi', __webpack_require__(216));
-	hljs.registerLanguage('diff', __webpack_require__(217));
-	hljs.registerLanguage('django', __webpack_require__(218));
-	hljs.registerLanguage('dns', __webpack_require__(219));
-	hljs.registerLanguage('dockerfile', __webpack_require__(220));
-	hljs.registerLanguage('dos', __webpack_require__(221));
-	hljs.registerLanguage('dsconfig', __webpack_require__(222));
-	hljs.registerLanguage('dts', __webpack_require__(223));
-	hljs.registerLanguage('dust', __webpack_require__(224));
-	hljs.registerLanguage('ebnf', __webpack_require__(225));
-	hljs.registerLanguage('elixir', __webpack_require__(226));
-	hljs.registerLanguage('elm', __webpack_require__(227));
-	hljs.registerLanguage('ruby', __webpack_require__(228));
-	hljs.registerLanguage('erb', __webpack_require__(229));
-	hljs.registerLanguage('erlang-repl', __webpack_require__(230));
-	hljs.registerLanguage('erlang', __webpack_require__(231));
-	hljs.registerLanguage('excel', __webpack_require__(232));
-	hljs.registerLanguage('fix', __webpack_require__(233));
-	hljs.registerLanguage('flix', __webpack_require__(234));
-	hljs.registerLanguage('fortran', __webpack_require__(235));
-	hljs.registerLanguage('fsharp', __webpack_require__(236));
-	hljs.registerLanguage('gams', __webpack_require__(237));
-	hljs.registerLanguage('gauss', __webpack_require__(238));
-	hljs.registerLanguage('gcode', __webpack_require__(239));
-	hljs.registerLanguage('gherkin', __webpack_require__(240));
-	hljs.registerLanguage('glsl', __webpack_require__(241));
-	hljs.registerLanguage('go', __webpack_require__(242));
-	hljs.registerLanguage('golo', __webpack_require__(243));
-	hljs.registerLanguage('gradle', __webpack_require__(244));
-	hljs.registerLanguage('groovy', __webpack_require__(245));
-	hljs.registerLanguage('haml', __webpack_require__(246));
-	hljs.registerLanguage('handlebars', __webpack_require__(247));
-	hljs.registerLanguage('haskell', __webpack_require__(248));
-	hljs.registerLanguage('haxe', __webpack_require__(249));
-	hljs.registerLanguage('hsp', __webpack_require__(250));
-	hljs.registerLanguage('htmlbars', __webpack_require__(251));
-	hljs.registerLanguage('http', __webpack_require__(252));
-	hljs.registerLanguage('hy', __webpack_require__(253));
-	hljs.registerLanguage('inform7', __webpack_require__(254));
-	hljs.registerLanguage('ini', __webpack_require__(255));
-	hljs.registerLanguage('irpf90', __webpack_require__(256));
-	hljs.registerLanguage('java', __webpack_require__(257));
-	hljs.registerLanguage('javascript', __webpack_require__(258));
-	hljs.registerLanguage('jboss-cli', __webpack_require__(259));
-	hljs.registerLanguage('json', __webpack_require__(260));
-	hljs.registerLanguage('julia', __webpack_require__(261));
-	hljs.registerLanguage('julia-repl', __webpack_require__(262));
-	hljs.registerLanguage('kotlin', __webpack_require__(263));
-	hljs.registerLanguage('lasso', __webpack_require__(264));
-	hljs.registerLanguage('ldif', __webpack_require__(265));
-	hljs.registerLanguage('leaf', __webpack_require__(266));
-	hljs.registerLanguage('less', __webpack_require__(267));
-	hljs.registerLanguage('lisp', __webpack_require__(268));
-	hljs.registerLanguage('livecodeserver', __webpack_require__(269));
-	hljs.registerLanguage('livescript', __webpack_require__(270));
-	hljs.registerLanguage('llvm', __webpack_require__(271));
-	hljs.registerLanguage('lsl', __webpack_require__(272));
-	hljs.registerLanguage('lua', __webpack_require__(273));
-	hljs.registerLanguage('makefile', __webpack_require__(274));
-	hljs.registerLanguage('mathematica', __webpack_require__(275));
-	hljs.registerLanguage('matlab', __webpack_require__(276));
-	hljs.registerLanguage('maxima', __webpack_require__(277));
-	hljs.registerLanguage('mel', __webpack_require__(278));
-	hljs.registerLanguage('mercury', __webpack_require__(279));
-	hljs.registerLanguage('mipsasm', __webpack_require__(280));
-	hljs.registerLanguage('mizar', __webpack_require__(281));
-	hljs.registerLanguage('perl', __webpack_require__(282));
-	hljs.registerLanguage('mojolicious', __webpack_require__(283));
-	hljs.registerLanguage('monkey', __webpack_require__(284));
-	hljs.registerLanguage('moonscript', __webpack_require__(285));
-	hljs.registerLanguage('n1ql', __webpack_require__(286));
-	hljs.registerLanguage('nginx', __webpack_require__(287));
-	hljs.registerLanguage('nimrod', __webpack_require__(288));
-	hljs.registerLanguage('nix', __webpack_require__(289));
-	hljs.registerLanguage('nsis', __webpack_require__(290));
-	hljs.registerLanguage('objectivec', __webpack_require__(291));
-	hljs.registerLanguage('ocaml', __webpack_require__(292));
-	hljs.registerLanguage('openscad', __webpack_require__(293));
-	hljs.registerLanguage('oxygene', __webpack_require__(294));
-	hljs.registerLanguage('parser3', __webpack_require__(295));
-	hljs.registerLanguage('pf', __webpack_require__(296));
-	hljs.registerLanguage('php', __webpack_require__(297));
-	hljs.registerLanguage('pony', __webpack_require__(298));
-	hljs.registerLanguage('powershell', __webpack_require__(299));
-	hljs.registerLanguage('processing', __webpack_require__(300));
-	hljs.registerLanguage('profile', __webpack_require__(301));
-	hljs.registerLanguage('prolog', __webpack_require__(302));
-	hljs.registerLanguage('protobuf', __webpack_require__(303));
-	hljs.registerLanguage('puppet', __webpack_require__(304));
-	hljs.registerLanguage('purebasic', __webpack_require__(305));
-	hljs.registerLanguage('python', __webpack_require__(306));
-	hljs.registerLanguage('q', __webpack_require__(307));
-	hljs.registerLanguage('qml', __webpack_require__(308));
-	hljs.registerLanguage('r', __webpack_require__(309));
-	hljs.registerLanguage('rib', __webpack_require__(310));
-	hljs.registerLanguage('roboconf', __webpack_require__(311));
-	hljs.registerLanguage('routeros', __webpack_require__(312));
-	hljs.registerLanguage('rsl', __webpack_require__(313));
-	hljs.registerLanguage('ruleslanguage', __webpack_require__(314));
-	hljs.registerLanguage('rust', __webpack_require__(315));
-	hljs.registerLanguage('scala', __webpack_require__(316));
-	hljs.registerLanguage('scheme', __webpack_require__(317));
-	hljs.registerLanguage('scilab', __webpack_require__(318));
-	hljs.registerLanguage('scss', __webpack_require__(319));
-	hljs.registerLanguage('shell', __webpack_require__(320));
-	hljs.registerLanguage('smali', __webpack_require__(321));
-	hljs.registerLanguage('smalltalk', __webpack_require__(322));
-	hljs.registerLanguage('sml', __webpack_require__(323));
-	hljs.registerLanguage('sqf', __webpack_require__(324));
-	hljs.registerLanguage('sql', __webpack_require__(325));
-	hljs.registerLanguage('stan', __webpack_require__(326));
-	hljs.registerLanguage('stata', __webpack_require__(327));
-	hljs.registerLanguage('step21', __webpack_require__(328));
-	hljs.registerLanguage('stylus', __webpack_require__(329));
-	hljs.registerLanguage('subunit', __webpack_require__(330));
-	hljs.registerLanguage('swift', __webpack_require__(331));
-	hljs.registerLanguage('taggerscript', __webpack_require__(332));
-	hljs.registerLanguage('yaml', __webpack_require__(333));
-	hljs.registerLanguage('tap', __webpack_require__(334));
-	hljs.registerLanguage('tcl', __webpack_require__(335));
-	hljs.registerLanguage('tex', __webpack_require__(336));
-	hljs.registerLanguage('thrift', __webpack_require__(337));
-	hljs.registerLanguage('tp', __webpack_require__(338));
-	hljs.registerLanguage('twig', __webpack_require__(339));
-	hljs.registerLanguage('typescript', __webpack_require__(340));
-	hljs.registerLanguage('vala', __webpack_require__(341));
-	hljs.registerLanguage('vbnet', __webpack_require__(342));
-	hljs.registerLanguage('vbscript', __webpack_require__(343));
-	hljs.registerLanguage('vbscript-html', __webpack_require__(344));
-	hljs.registerLanguage('verilog', __webpack_require__(345));
-	hljs.registerLanguage('vhdl', __webpack_require__(346));
-	hljs.registerLanguage('vim', __webpack_require__(347));
-	hljs.registerLanguage('x86asm', __webpack_require__(348));
-	hljs.registerLanguage('xl', __webpack_require__(349));
-	hljs.registerLanguage('xquery', __webpack_require__(350));
-	hljs.registerLanguage('zephir', __webpack_require__(351));
+	hljs.registerLanguage('1c', __webpack_require__(180));
+	hljs.registerLanguage('abnf', __webpack_require__(181));
+	hljs.registerLanguage('accesslog', __webpack_require__(182));
+	hljs.registerLanguage('actionscript', __webpack_require__(183));
+	hljs.registerLanguage('ada', __webpack_require__(184));
+	hljs.registerLanguage('apache', __webpack_require__(185));
+	hljs.registerLanguage('applescript', __webpack_require__(186));
+	hljs.registerLanguage('cpp', __webpack_require__(187));
+	hljs.registerLanguage('arduino', __webpack_require__(188));
+	hljs.registerLanguage('armasm', __webpack_require__(189));
+	hljs.registerLanguage('xml', __webpack_require__(190));
+	hljs.registerLanguage('asciidoc', __webpack_require__(191));
+	hljs.registerLanguage('aspectj', __webpack_require__(192));
+	hljs.registerLanguage('autohotkey', __webpack_require__(193));
+	hljs.registerLanguage('autoit', __webpack_require__(194));
+	hljs.registerLanguage('avrasm', __webpack_require__(195));
+	hljs.registerLanguage('awk', __webpack_require__(196));
+	hljs.registerLanguage('axapta', __webpack_require__(197));
+	hljs.registerLanguage('bash', __webpack_require__(198));
+	hljs.registerLanguage('basic', __webpack_require__(199));
+	hljs.registerLanguage('bnf', __webpack_require__(200));
+	hljs.registerLanguage('brainfuck', __webpack_require__(201));
+	hljs.registerLanguage('cal', __webpack_require__(202));
+	hljs.registerLanguage('capnproto', __webpack_require__(203));
+	hljs.registerLanguage('ceylon', __webpack_require__(204));
+	hljs.registerLanguage('clean', __webpack_require__(205));
+	hljs.registerLanguage('clojure', __webpack_require__(206));
+	hljs.registerLanguage('clojure-repl', __webpack_require__(207));
+	hljs.registerLanguage('cmake', __webpack_require__(208));
+	hljs.registerLanguage('coffeescript', __webpack_require__(209));
+	hljs.registerLanguage('coq', __webpack_require__(210));
+	hljs.registerLanguage('cos', __webpack_require__(211));
+	hljs.registerLanguage('crmsh', __webpack_require__(212));
+	hljs.registerLanguage('crystal', __webpack_require__(213));
+	hljs.registerLanguage('cs', __webpack_require__(214));
+	hljs.registerLanguage('csp', __webpack_require__(215));
+	hljs.registerLanguage('css', __webpack_require__(216));
+	hljs.registerLanguage('d', __webpack_require__(217));
+	hljs.registerLanguage('markdown', __webpack_require__(218));
+	hljs.registerLanguage('dart', __webpack_require__(219));
+	hljs.registerLanguage('delphi', __webpack_require__(220));
+	hljs.registerLanguage('diff', __webpack_require__(221));
+	hljs.registerLanguage('django', __webpack_require__(222));
+	hljs.registerLanguage('dns', __webpack_require__(223));
+	hljs.registerLanguage('dockerfile', __webpack_require__(224));
+	hljs.registerLanguage('dos', __webpack_require__(225));
+	hljs.registerLanguage('dsconfig', __webpack_require__(226));
+	hljs.registerLanguage('dts', __webpack_require__(227));
+	hljs.registerLanguage('dust', __webpack_require__(228));
+	hljs.registerLanguage('ebnf', __webpack_require__(229));
+	hljs.registerLanguage('elixir', __webpack_require__(230));
+	hljs.registerLanguage('elm', __webpack_require__(231));
+	hljs.registerLanguage('ruby', __webpack_require__(232));
+	hljs.registerLanguage('erb', __webpack_require__(233));
+	hljs.registerLanguage('erlang-repl', __webpack_require__(234));
+	hljs.registerLanguage('erlang', __webpack_require__(235));
+	hljs.registerLanguage('excel', __webpack_require__(236));
+	hljs.registerLanguage('fix', __webpack_require__(237));
+	hljs.registerLanguage('flix', __webpack_require__(238));
+	hljs.registerLanguage('fortran', __webpack_require__(239));
+	hljs.registerLanguage('fsharp', __webpack_require__(240));
+	hljs.registerLanguage('gams', __webpack_require__(241));
+	hljs.registerLanguage('gauss', __webpack_require__(242));
+	hljs.registerLanguage('gcode', __webpack_require__(243));
+	hljs.registerLanguage('gherkin', __webpack_require__(244));
+	hljs.registerLanguage('glsl', __webpack_require__(245));
+	hljs.registerLanguage('go', __webpack_require__(246));
+	hljs.registerLanguage('golo', __webpack_require__(247));
+	hljs.registerLanguage('gradle', __webpack_require__(248));
+	hljs.registerLanguage('groovy', __webpack_require__(249));
+	hljs.registerLanguage('haml', __webpack_require__(250));
+	hljs.registerLanguage('handlebars', __webpack_require__(251));
+	hljs.registerLanguage('haskell', __webpack_require__(252));
+	hljs.registerLanguage('haxe', __webpack_require__(253));
+	hljs.registerLanguage('hsp', __webpack_require__(254));
+	hljs.registerLanguage('htmlbars', __webpack_require__(255));
+	hljs.registerLanguage('http', __webpack_require__(256));
+	hljs.registerLanguage('hy', __webpack_require__(257));
+	hljs.registerLanguage('inform7', __webpack_require__(258));
+	hljs.registerLanguage('ini', __webpack_require__(259));
+	hljs.registerLanguage('irpf90', __webpack_require__(260));
+	hljs.registerLanguage('java', __webpack_require__(261));
+	hljs.registerLanguage('javascript', __webpack_require__(262));
+	hljs.registerLanguage('jboss-cli', __webpack_require__(263));
+	hljs.registerLanguage('json', __webpack_require__(264));
+	hljs.registerLanguage('julia', __webpack_require__(265));
+	hljs.registerLanguage('julia-repl', __webpack_require__(266));
+	hljs.registerLanguage('kotlin', __webpack_require__(267));
+	hljs.registerLanguage('lasso', __webpack_require__(268));
+	hljs.registerLanguage('ldif', __webpack_require__(269));
+	hljs.registerLanguage('leaf', __webpack_require__(270));
+	hljs.registerLanguage('less', __webpack_require__(271));
+	hljs.registerLanguage('lisp', __webpack_require__(272));
+	hljs.registerLanguage('livecodeserver', __webpack_require__(273));
+	hljs.registerLanguage('livescript', __webpack_require__(274));
+	hljs.registerLanguage('llvm', __webpack_require__(275));
+	hljs.registerLanguage('lsl', __webpack_require__(276));
+	hljs.registerLanguage('lua', __webpack_require__(277));
+	hljs.registerLanguage('makefile', __webpack_require__(278));
+	hljs.registerLanguage('mathematica', __webpack_require__(279));
+	hljs.registerLanguage('matlab', __webpack_require__(280));
+	hljs.registerLanguage('maxima', __webpack_require__(281));
+	hljs.registerLanguage('mel', __webpack_require__(282));
+	hljs.registerLanguage('mercury', __webpack_require__(283));
+	hljs.registerLanguage('mipsasm', __webpack_require__(284));
+	hljs.registerLanguage('mizar', __webpack_require__(285));
+	hljs.registerLanguage('perl', __webpack_require__(286));
+	hljs.registerLanguage('mojolicious', __webpack_require__(287));
+	hljs.registerLanguage('monkey', __webpack_require__(288));
+	hljs.registerLanguage('moonscript', __webpack_require__(289));
+	hljs.registerLanguage('n1ql', __webpack_require__(290));
+	hljs.registerLanguage('nginx', __webpack_require__(291));
+	hljs.registerLanguage('nimrod', __webpack_require__(292));
+	hljs.registerLanguage('nix', __webpack_require__(293));
+	hljs.registerLanguage('nsis', __webpack_require__(294));
+	hljs.registerLanguage('objectivec', __webpack_require__(295));
+	hljs.registerLanguage('ocaml', __webpack_require__(296));
+	hljs.registerLanguage('openscad', __webpack_require__(297));
+	hljs.registerLanguage('oxygene', __webpack_require__(298));
+	hljs.registerLanguage('parser3', __webpack_require__(299));
+	hljs.registerLanguage('pf', __webpack_require__(300));
+	hljs.registerLanguage('php', __webpack_require__(301));
+	hljs.registerLanguage('pony', __webpack_require__(302));
+	hljs.registerLanguage('powershell', __webpack_require__(303));
+	hljs.registerLanguage('processing', __webpack_require__(304));
+	hljs.registerLanguage('profile', __webpack_require__(305));
+	hljs.registerLanguage('prolog', __webpack_require__(306));
+	hljs.registerLanguage('protobuf', __webpack_require__(307));
+	hljs.registerLanguage('puppet', __webpack_require__(308));
+	hljs.registerLanguage('purebasic', __webpack_require__(309));
+	hljs.registerLanguage('python', __webpack_require__(310));
+	hljs.registerLanguage('q', __webpack_require__(311));
+	hljs.registerLanguage('qml', __webpack_require__(312));
+	hljs.registerLanguage('r', __webpack_require__(313));
+	hljs.registerLanguage('rib', __webpack_require__(314));
+	hljs.registerLanguage('roboconf', __webpack_require__(315));
+	hljs.registerLanguage('routeros', __webpack_require__(316));
+	hljs.registerLanguage('rsl', __webpack_require__(317));
+	hljs.registerLanguage('ruleslanguage', __webpack_require__(318));
+	hljs.registerLanguage('rust', __webpack_require__(319));
+	hljs.registerLanguage('scala', __webpack_require__(320));
+	hljs.registerLanguage('scheme', __webpack_require__(321));
+	hljs.registerLanguage('scilab', __webpack_require__(322));
+	hljs.registerLanguage('scss', __webpack_require__(323));
+	hljs.registerLanguage('shell', __webpack_require__(324));
+	hljs.registerLanguage('smali', __webpack_require__(325));
+	hljs.registerLanguage('smalltalk', __webpack_require__(326));
+	hljs.registerLanguage('sml', __webpack_require__(327));
+	hljs.registerLanguage('sqf', __webpack_require__(328));
+	hljs.registerLanguage('sql', __webpack_require__(329));
+	hljs.registerLanguage('stan', __webpack_require__(330));
+	hljs.registerLanguage('stata', __webpack_require__(331));
+	hljs.registerLanguage('step21', __webpack_require__(332));
+	hljs.registerLanguage('stylus', __webpack_require__(333));
+	hljs.registerLanguage('subunit', __webpack_require__(334));
+	hljs.registerLanguage('swift', __webpack_require__(335));
+	hljs.registerLanguage('taggerscript', __webpack_require__(336));
+	hljs.registerLanguage('yaml', __webpack_require__(337));
+	hljs.registerLanguage('tap', __webpack_require__(338));
+	hljs.registerLanguage('tcl', __webpack_require__(339));
+	hljs.registerLanguage('tex', __webpack_require__(340));
+	hljs.registerLanguage('thrift', __webpack_require__(341));
+	hljs.registerLanguage('tp', __webpack_require__(342));
+	hljs.registerLanguage('twig', __webpack_require__(343));
+	hljs.registerLanguage('typescript', __webpack_require__(344));
+	hljs.registerLanguage('vala', __webpack_require__(345));
+	hljs.registerLanguage('vbnet', __webpack_require__(346));
+	hljs.registerLanguage('vbscript', __webpack_require__(347));
+	hljs.registerLanguage('vbscript-html', __webpack_require__(348));
+	hljs.registerLanguage('verilog', __webpack_require__(349));
+	hljs.registerLanguage('vhdl', __webpack_require__(350));
+	hljs.registerLanguage('vim', __webpack_require__(351));
+	hljs.registerLanguage('x86asm', __webpack_require__(352));
+	hljs.registerLanguage('xl', __webpack_require__(353));
+	hljs.registerLanguage('xquery', __webpack_require__(354));
+	hljs.registerLanguage('zephir', __webpack_require__(355));
 
 	module.exports = hljs;
 
 /***/ }),
-/* 175 */
+/* 179 */
 /***/ (function(module, exports, __webpack_require__) {
 
 	/*
@@ -23352,7 +23395,7 @@ return /******/ (function(modules) { // webpackBootstrap
 
 
 /***/ }),
-/* 176 */
+/* 180 */
 /***/ (function(module, exports) {
 
 	module.exports = function(hljs){
@@ -23866,7 +23909,7 @@ return /******/ (function(modules) { // webpackBootstrap
 	};
 
 /***/ }),
-/* 177 */
+/* 181 */
 /***/ (function(module, exports) {
 
 	module.exports = function(hljs) {
@@ -23941,7 +23984,7 @@ return /******/ (function(modules) { // webpackBootstrap
 	};
 
 /***/ }),
-/* 178 */
+/* 182 */
 /***/ (function(module, exports) {
 
 	module.exports = function(hljs) {
@@ -23983,7 +24026,7 @@ return /******/ (function(modules) { // webpackBootstrap
 	};
 
 /***/ }),
-/* 179 */
+/* 183 */
 /***/ (function(module, exports) {
 
 	module.exports = function(hljs) {
@@ -24061,7 +24104,7 @@ return /******/ (function(modules) { // webpackBootstrap
 	};
 
 /***/ }),
-/* 180 */
+/* 184 */
 /***/ (function(module, exports) {
 
 	module.exports = // We try to support full Ada2012
@@ -24238,7 +24281,7 @@ return /******/ (function(modules) { // webpackBootstrap
 	};
 
 /***/ }),
-/* 181 */
+/* 185 */
 /***/ (function(module, exports) {
 
 	module.exports = function(hljs) {
@@ -24288,7 +24331,7 @@ return /******/ (function(modules) { // webpackBootstrap
 	};
 
 /***/ }),
-/* 182 */
+/* 186 */
 /***/ (function(module, exports) {
 
 	module.exports = function(hljs) {
@@ -24378,7 +24421,7 @@ return /******/ (function(modules) { // webpackBootstrap
 	};
 
 /***/ }),
-/* 183 */
+/* 187 */
 /***/ (function(module, exports) {
 
 	module.exports = function(hljs) {
@@ -24557,7 +24600,7 @@ return /******/ (function(modules) { // webpackBootstrap
 	};
 
 /***/ }),
-/* 184 */
+/* 188 */
 /***/ (function(module, exports) {
 
 	module.exports = function(hljs) {
@@ -24661,7 +24704,7 @@ return /******/ (function(modules) { // webpackBootstrap
 	};
 
 /***/ }),
-/* 185 */
+/* 189 */
 /***/ (function(module, exports) {
 
 	module.exports = function(hljs) {
@@ -24757,7 +24800,7 @@ return /******/ (function(modules) { // webpackBootstrap
 	};
 
 /***/ }),
-/* 186 */
+/* 190 */
 /***/ (function(module, exports) {
 
 	module.exports = function(hljs) {
@@ -24864,7 +24907,7 @@ return /******/ (function(modules) { // webpackBootstrap
 	};
 
 /***/ }),
-/* 187 */
+/* 191 */
 /***/ (function(module, exports) {
 
 	module.exports = function(hljs) {
@@ -25056,7 +25099,7 @@ return /******/ (function(modules) { // webpackBootstrap
 	};
 
 /***/ }),
-/* 188 */
+/* 192 */
 /***/ (function(module, exports) {
 
 	module.exports = function (hljs) {
@@ -25205,7 +25248,7 @@ return /******/ (function(modules) { // webpackBootstrap
 	};
 
 /***/ }),
-/* 189 */
+/* 193 */
 /***/ (function(module, exports) {
 
 	module.exports = function(hljs) {
@@ -25268,7 +25311,7 @@ return /******/ (function(modules) { // webpackBootstrap
 	};
 
 /***/ }),
-/* 190 */
+/* 194 */
 /***/ (function(module, exports) {
 
 	module.exports = function(hljs) {
@@ -25408,7 +25451,7 @@ return /******/ (function(modules) { // webpackBootstrap
 	};
 
 /***/ }),
-/* 191 */
+/* 195 */
 /***/ (function(module, exports) {
 
 	module.exports = function(hljs) {
@@ -25474,7 +25517,7 @@ return /******/ (function(modules) { // webpackBootstrap
 	};
 
 /***/ }),
-/* 192 */
+/* 196 */
 /***/ (function(module, exports) {
 
 	module.exports = function(hljs) {
@@ -25531,7 +25574,7 @@ return /******/ (function(modules) { // webpackBootstrap
 	};
 
 /***/ }),
-/* 193 */
+/* 197 */
 /***/ (function(module, exports) {
 
 	module.exports = function(hljs) {
@@ -25566,7 +25609,7 @@ return /******/ (function(modules) { // webpackBootstrap
 	};
 
 /***/ }),
-/* 194 */
+/* 198 */
 /***/ (function(module, exports) {
 
 	module.exports = function(hljs) {
@@ -25645,7 +25688,7 @@ return /******/ (function(modules) { // webpackBootstrap
 	};
 
 /***/ }),
-/* 195 */
+/* 199 */
 /***/ (function(module, exports) {
 
 	module.exports = function(hljs) {
@@ -25700,7 +25743,7 @@ return /******/ (function(modules) { // webpackBootstrap
 	};
 
 /***/ }),
-/* 196 */
+/* 200 */
 /***/ (function(module, exports) {
 
 	module.exports = function(hljs){
@@ -25733,7 +25776,7 @@ return /******/ (function(modules) { // webpackBootstrap
 	};
 
 /***/ }),
-/* 197 */
+/* 201 */
 /***/ (function(module, exports) {
 
 	module.exports = function(hljs){
@@ -25774,7 +25817,7 @@ return /******/ (function(modules) { // webpackBootstrap
 	};
 
 /***/ }),
-/* 198 */
+/* 202 */
 /***/ (function(module, exports) {
 
 	module.exports = function(hljs) {
@@ -25858,7 +25901,7 @@ return /******/ (function(modules) { // webpackBootstrap
 	};
 
 /***/ }),
-/* 199 */
+/* 203 */
 /***/ (function(module, exports) {
 
 	module.exports = function(hljs) {
@@ -25911,7 +25954,7 @@ return /******/ (function(modules) { // webpackBootstrap
 	};
 
 /***/ }),
-/* 200 */
+/* 204 */
 /***/ (function(module, exports) {
 
 	module.exports = function(hljs) {
@@ -25982,7 +26025,7 @@ return /******/ (function(modules) { // webpackBootstrap
 	};
 
 /***/ }),
-/* 201 */
+/* 205 */
 /***/ (function(module, exports) {
 
 	module.exports = function(hljs) {
@@ -26011,7 +26054,7 @@ return /******/ (function(modules) { // webpackBootstrap
 	};
 
 /***/ }),
-/* 202 */
+/* 206 */
 /***/ (function(module, exports) {
 
 	module.exports = function(hljs) {
@@ -26111,7 +26154,7 @@ return /******/ (function(modules) { // webpackBootstrap
 	};
 
 /***/ }),
-/* 203 */
+/* 207 */
 /***/ (function(module, exports) {
 
 	module.exports = function(hljs) {
@@ -26130,7 +26173,7 @@ return /******/ (function(modules) { // webpackBootstrap
 	};
 
 /***/ }),
-/* 204 */
+/* 208 */
 /***/ (function(module, exports) {
 
 	module.exports = function(hljs) {
@@ -26172,7 +26215,7 @@ return /******/ (function(modules) { // webpackBootstrap
 	};
 
 /***/ }),
-/* 205 */
+/* 209 */
 /***/ (function(module, exports) {
 
 	module.exports = function(hljs) {
@@ -26322,7 +26365,7 @@ return /******/ (function(modules) { // webpackBootstrap
 	};
 
 /***/ }),
-/* 206 */
+/* 210 */
 /***/ (function(module, exports) {
 
 	module.exports = function(hljs) {
@@ -26393,7 +26436,7 @@ return /******/ (function(modules) { // webpackBootstrap
 	};
 
 /***/ }),
-/* 207 */
+/* 211 */
 /***/ (function(module, exports) {
 
 	module.exports = function cos (hljs) {
@@ -26521,7 +26564,7 @@ return /******/ (function(modules) { // webpackBootstrap
 	};
 
 /***/ }),
-/* 208 */
+/* 212 */
 /***/ (function(module, exports) {
 
 	module.exports = function(hljs) {
@@ -26619,7 +26662,7 @@ return /******/ (function(modules) { // webpackBootstrap
 	};
 
 /***/ }),
-/* 209 */
+/* 213 */
 /***/ (function(module, exports) {
 
 	module.exports = function(hljs) {
@@ -26817,7 +26860,7 @@ return /******/ (function(modules) { // webpackBootstrap
 	};
 
 /***/ }),
-/* 210 */
+/* 214 */
 /***/ (function(module, exports) {
 
 	module.exports = function(hljs) {
@@ -26998,7 +27041,7 @@ return /******/ (function(modules) { // webpackBootstrap
 	};
 
 /***/ }),
-/* 211 */
+/* 215 */
 /***/ (function(module, exports) {
 
 	module.exports = function(hljs) {
@@ -27024,7 +27067,7 @@ return /******/ (function(modules) { // webpackBootstrap
 	};
 
 /***/ }),
-/* 212 */
+/* 216 */
 /***/ (function(module, exports) {
 
 	module.exports = function(hljs) {
@@ -27133,7 +27176,7 @@ return /******/ (function(modules) { // webpackBootstrap
 	};
 
 /***/ }),
-/* 213 */
+/* 217 */
 /***/ (function(module, exports) {
 
 	module.exports = /**
@@ -27395,7 +27438,7 @@ return /******/ (function(modules) { // webpackBootstrap
 	};
 
 /***/ }),
-/* 214 */
+/* 218 */
 /***/ (function(module, exports) {
 
 	module.exports = function(hljs) {
@@ -27507,7 +27550,7 @@ return /******/ (function(modules) { // webpackBootstrap
 	};
 
 /***/ }),
-/* 215 */
+/* 219 */
 /***/ (function(module, exports) {
 
 	module.exports = function (hljs) {
@@ -27612,7 +27655,7 @@ return /******/ (function(modules) { // webpackBootstrap
 	};
 
 /***/ }),
-/* 216 */
+/* 220 */
 /***/ (function(module, exports) {
 
 	module.exports = function(hljs) {
@@ -27685,7 +27728,7 @@ return /******/ (function(modules) { // webpackBootstrap
 	};
 
 /***/ }),
-/* 217 */
+/* 221 */
 /***/ (function(module, exports) {
 
 	module.exports = function(hljs) {
@@ -27729,7 +27772,7 @@ return /******/ (function(modules) { // webpackBootstrap
 	};
 
 /***/ }),
-/* 218 */
+/* 222 */
 /***/ (function(module, exports) {
 
 	module.exports = function(hljs) {
@@ -27797,7 +27840,7 @@ return /******/ (function(modules) { // webpackBootstrap
 	};
 
 /***/ }),
-/* 219 */
+/* 223 */
 /***/ (function(module, exports) {
 
 	module.exports = function(hljs) {
@@ -27830,7 +27873,7 @@ return /******/ (function(modules) { // webpackBootstrap
 	};
 
 /***/ }),
-/* 220 */
+/* 224 */
 /***/ (function(module, exports) {
 
 	module.exports = function(hljs) {
@@ -27856,7 +27899,7 @@ return /******/ (function(modules) { // webpackBootstrap
 	};
 
 /***/ }),
-/* 221 */
+/* 225 */
 /***/ (function(module, exports) {
 
 	module.exports = function(hljs) {
@@ -27912,7 +27955,7 @@ return /******/ (function(modules) { // webpackBootstrap
 	};
 
 /***/ }),
-/* 222 */
+/* 226 */
 /***/ (function(module, exports) {
 
 	module.exports = function(hljs) {
@@ -27963,7 +28006,7 @@ return /******/ (function(modules) { // webpackBootstrap
 	};
 
 /***/ }),
-/* 223 */
+/* 227 */
 /***/ (function(module, exports) {
 
 	module.exports = function(hljs) {
@@ -28091,7 +28134,7 @@ return /******/ (function(modules) { // webpackBootstrap
 	};
 
 /***/ }),
-/* 224 */
+/* 228 */
 /***/ (function(module, exports) {
 
 	module.exports = function(hljs) {
@@ -28127,7 +28170,7 @@ return /******/ (function(modules) { // webpackBootstrap
 	};
 
 /***/ }),
-/* 225 */
+/* 229 */
 /***/ (function(module, exports) {
 
 	module.exports = function(hljs) {
@@ -28164,7 +28207,7 @@ return /******/ (function(modules) { // webpackBootstrap
 	};
 
 /***/ }),
-/* 226 */
+/* 230 */
 /***/ (function(module, exports) {
 
 	module.exports = function(hljs) {
@@ -28265,7 +28308,7 @@ return /******/ (function(modules) { // webpackBootstrap
 	};
 
 /***/ }),
-/* 227 */
+/* 231 */
 /***/ (function(module, exports) {
 
 	module.exports = function(hljs) {
@@ -28353,7 +28396,7 @@ return /******/ (function(modules) { // webpackBootstrap
 	};
 
 /***/ }),
-/* 228 */
+/* 232 */
 /***/ (function(module, exports) {
 
 	module.exports = function(hljs) {
@@ -28534,7 +28577,7 @@ return /******/ (function(modules) { // webpackBootstrap
 	};
 
 /***/ }),
-/* 229 */
+/* 233 */
 /***/ (function(module, exports) {
 
 	module.exports = function(hljs) {
@@ -28553,7 +28596,7 @@ return /******/ (function(modules) { // webpackBootstrap
 	};
 
 /***/ }),
-/* 230 */
+/* 234 */
 /***/ (function(module, exports) {
 
 	module.exports = function(hljs) {
@@ -28603,7 +28646,7 @@ return /******/ (function(modules) { // webpackBootstrap
 	};
 
 /***/ }),
-/* 231 */
+/* 235 */
 /***/ (function(module, exports) {
 
 	module.exports = function(hljs) {
@@ -28753,7 +28796,7 @@ return /******/ (function(modules) { // webpackBootstrap
 	};
 
 /***/ }),
-/* 232 */
+/* 236 */
 /***/ (function(module, exports) {
 
 	module.exports = function(hljs) {
@@ -28805,7 +28848,7 @@ return /******/ (function(modules) { // webpackBootstrap
 	};
 
 /***/ }),
-/* 233 */
+/* 237 */
 /***/ (function(module, exports) {
 
 	module.exports = function(hljs) {
@@ -28838,7 +28881,7 @@ return /******/ (function(modules) { // webpackBootstrap
 	};
 
 /***/ }),
-/* 234 */
+/* 238 */
 /***/ (function(module, exports) {
 
 	module.exports = function (hljs) {
@@ -28887,7 +28930,7 @@ return /******/ (function(modules) { // webpackBootstrap
 	};
 
 /***/ }),
-/* 235 */
+/* 239 */
 /***/ (function(module, exports) {
 
 	module.exports = function(hljs) {
@@ -28962,7 +29005,7 @@ return /******/ (function(modules) { // webpackBootstrap
 	};
 
 /***/ }),
-/* 236 */
+/* 240 */
 /***/ (function(module, exports) {
 
 	module.exports = function(hljs) {
@@ -29025,7 +29068,7 @@ return /******/ (function(modules) { // webpackBootstrap
 	};
 
 /***/ }),
-/* 237 */
+/* 241 */
 /***/ (function(module, exports) {
 
 	module.exports = function (hljs) {
@@ -29183,7 +29226,7 @@ return /******/ (function(modules) { // webpackBootstrap
 	};
 
 /***/ }),
-/* 238 */
+/* 242 */
 /***/ (function(module, exports) {
 
 	module.exports = function(hljs) {
@@ -29411,7 +29454,7 @@ return /******/ (function(modules) { // webpackBootstrap
 	};
 
 /***/ }),
-/* 239 */
+/* 243 */
 /***/ (function(module, exports) {
 
 	module.exports = function(hljs) {
@@ -29482,7 +29525,7 @@ return /******/ (function(modules) { // webpackBootstrap
 	};
 
 /***/ }),
-/* 240 */
+/* 244 */
 /***/ (function(module, exports) {
 
 	module.exports = function (hljs) {
@@ -29523,7 +29566,7 @@ return /******/ (function(modules) { // webpackBootstrap
 	};
 
 /***/ }),
-/* 241 */
+/* 245 */
 /***/ (function(module, exports) {
 
 	module.exports = function(hljs) {
@@ -29644,7 +29687,7 @@ return /******/ (function(modules) { // webpackBootstrap
 	};
 
 /***/ }),
-/* 242 */
+/* 246 */
 /***/ (function(module, exports) {
 
 	module.exports = function(hljs) {
@@ -29702,7 +29745,7 @@ return /******/ (function(modules) { // webpackBootstrap
 	};
 
 /***/ }),
-/* 243 */
+/* 247 */
 /***/ (function(module, exports) {
 
 	module.exports = function(hljs) {
@@ -29729,7 +29772,7 @@ return /******/ (function(modules) { // webpackBootstrap
 	};
 
 /***/ }),
-/* 244 */
+/* 248 */
 /***/ (function(module, exports) {
 
 	module.exports = function(hljs) {
@@ -29768,7 +29811,7 @@ return /******/ (function(modules) { // webpackBootstrap
 	};
 
 /***/ }),
-/* 245 */
+/* 249 */
 /***/ (function(module, exports) {
 
 	module.exports = function(hljs) {
@@ -29866,7 +29909,7 @@ return /******/ (function(modules) { // webpackBootstrap
 	};
 
 /***/ }),
-/* 246 */
+/* 250 */
 /***/ (function(module, exports) {
 
 	module.exports = // TODO support filter tags like :javascript, support inline HTML
@@ -29977,7 +30020,7 @@ return /******/ (function(modules) { // webpackBootstrap
 	};
 
 /***/ }),
-/* 247 */
+/* 251 */
 /***/ (function(module, exports) {
 
 	module.exports = function(hljs) {
@@ -30015,7 +30058,7 @@ return /******/ (function(modules) { // webpackBootstrap
 	};
 
 /***/ }),
-/* 248 */
+/* 252 */
 /***/ (function(module, exports) {
 
 	module.exports = function(hljs) {
@@ -30141,7 +30184,7 @@ return /******/ (function(modules) { // webpackBootstrap
 	};
 
 /***/ }),
-/* 249 */
+/* 253 */
 /***/ (function(module, exports) {
 
 	module.exports = function(hljs) {
@@ -30257,7 +30300,7 @@ return /******/ (function(modules) { // webpackBootstrap
 	};
 
 /***/ }),
-/* 250 */
+/* 254 */
 /***/ (function(module, exports) {
 
 	module.exports = function(hljs) {
@@ -30307,7 +30350,7 @@ return /******/ (function(modules) { // webpackBootstrap
 	};
 
 /***/ }),
-/* 251 */
+/* 255 */
 /***/ (function(module, exports) {
 
 	module.exports = function(hljs) {
@@ -30382,7 +30425,7 @@ return /******/ (function(modules) { // webpackBootstrap
 	};
 
 /***/ }),
-/* 252 */
+/* 256 */
 /***/ (function(module, exports) {
 
 	module.exports = function(hljs) {
@@ -30427,7 +30470,7 @@ return /******/ (function(modules) { // webpackBootstrap
 	};
 
 /***/ }),
-/* 253 */
+/* 257 */
 /***/ (function(module, exports) {
 
 	module.exports = function(hljs) {
@@ -30533,7 +30576,7 @@ return /******/ (function(modules) { // webpackBootstrap
 	};
 
 /***/ }),
-/* 254 */
+/* 258 */
 /***/ (function(module, exports) {
 
 	module.exports = function(hljs) {
@@ -30594,7 +30637,7 @@ return /******/ (function(modules) { // webpackBootstrap
 	};
 
 /***/ }),
-/* 255 */
+/* 259 */
 /***/ (function(module, exports) {
 
 	module.exports = function(hljs) {
@@ -30664,7 +30707,7 @@ return /******/ (function(modules) { // webpackBootstrap
 	};
 
 /***/ }),
-/* 256 */
+/* 260 */
 /***/ (function(module, exports) {
 
 	module.exports = function(hljs) {
@@ -30744,7 +30787,7 @@ return /******/ (function(modules) { // webpackBootstrap
 	};
 
 /***/ }),
-/* 257 */
+/* 261 */
 /***/ (function(module, exports) {
 
 	module.exports = function(hljs) {
@@ -30856,7 +30899,7 @@ return /******/ (function(modules) { // webpackBootstrap
 	};
 
 /***/ }),
-/* 258 */
+/* 262 */
 /***/ (function(module, exports) {
 
 	module.exports = function(hljs) {
@@ -31031,7 +31074,7 @@ return /******/ (function(modules) { // webpackBootstrap
 	};
 
 /***/ }),
-/* 259 */
+/* 263 */
 /***/ (function(module, exports) {
 
 	module.exports = function (hljs) {
@@ -31082,7 +31125,7 @@ return /******/ (function(modules) { // webpackBootstrap
 	};
 
 /***/ }),
-/* 260 */
+/* 264 */
 /***/ (function(module, exports) {
 
 	module.exports = function(hljs) {
@@ -31123,7 +31166,7 @@ return /******/ (function(modules) { // webpackBootstrap
 	};
 
 /***/ }),
-/* 261 */
+/* 265 */
 /***/ (function(module, exports) {
 
 	module.exports = function(hljs) {
@@ -31289,7 +31332,7 @@ return /******/ (function(modules) { // webpackBootstrap
 	};
 
 /***/ }),
-/* 262 */
+/* 266 */
 /***/ (function(module, exports) {
 
 	module.exports = function(hljs) {
@@ -31317,7 +31360,7 @@ return /******/ (function(modules) { // webpackBootstrap
 	};
 
 /***/ }),
-/* 263 */
+/* 267 */
 /***/ (function(module, exports) {
 
 	module.exports = function(hljs) {
@@ -31495,7 +31538,7 @@ return /******/ (function(modules) { // webpackBootstrap
 	};
 
 /***/ }),
-/* 264 */
+/* 268 */
 /***/ (function(module, exports) {
 
 	module.exports = function(hljs) {
@@ -31662,7 +31705,7 @@ return /******/ (function(modules) { // webpackBootstrap
 	};
 
 /***/ }),
-/* 265 */
+/* 269 */
 /***/ (function(module, exports) {
 
 	module.exports = function(hljs) {
@@ -31689,7 +31732,7 @@ return /******/ (function(modules) { // webpackBootstrap
 	};
 
 /***/ }),
-/* 266 */
+/* 270 */
 /***/ (function(module, exports) {
 
 	module.exports = function (hljs) {
@@ -31733,7 +31776,7 @@ return /******/ (function(modules) { // webpackBootstrap
 	};
 
 /***/ }),
-/* 267 */
+/* 271 */
 /***/ (function(module, exports) {
 
 	module.exports = function(hljs) {
@@ -31877,7 +31920,7 @@ return /******/ (function(modules) { // webpackBootstrap
 	};
 
 /***/ }),
-/* 268 */
+/* 272 */
 /***/ (function(module, exports) {
 
 	module.exports = function(hljs) {
@@ -31984,7 +32027,7 @@ return /******/ (function(modules) { // webpackBootstrap
 	};
 
 /***/ }),
-/* 269 */
+/* 273 */
 /***/ (function(module, exports) {
 
 	module.exports = function(hljs) {
@@ -32145,7 +32188,7 @@ return /******/ (function(modules) { // webpackBootstrap
 	};
 
 /***/ }),
-/* 270 */
+/* 274 */
 /***/ (function(module, exports) {
 
 	module.exports = function(hljs) {
@@ -32298,7 +32341,7 @@ return /******/ (function(modules) { // webpackBootstrap
 	};
 
 /***/ }),
-/* 271 */
+/* 275 */
 /***/ (function(module, exports) {
 
 	module.exports = function(hljs) {
@@ -32391,7 +32434,7 @@ return /******/ (function(modules) { // webpackBootstrap
 	};
 
 /***/ }),
-/* 272 */
+/* 276 */
 /***/ (function(module, exports) {
 
 	module.exports = function(hljs) {
@@ -32478,7 +32521,7 @@ return /******/ (function(modules) { // webpackBootstrap
 	};
 
 /***/ }),
-/* 273 */
+/* 277 */
 /***/ (function(module, exports) {
 
 	module.exports = function(hljs) {
@@ -32548,7 +32591,7 @@ return /******/ (function(modules) { // webpackBootstrap
 	};
 
 /***/ }),
-/* 274 */
+/* 278 */
 /***/ (function(module, exports) {
 
 	module.exports = function(hljs) {
@@ -32633,7 +32676,7 @@ return /******/ (function(modules) { // webpackBootstrap
 	};
 
 /***/ }),
-/* 275 */
+/* 279 */
 /***/ (function(module, exports) {
 
 	module.exports = function(hljs) {
@@ -32695,7 +32738,7 @@ return /******/ (function(modules) { // webpackBootstrap
 	};
 
 /***/ }),
-/* 276 */
+/* 280 */
 /***/ (function(module, exports) {
 
 	module.exports = function(hljs) {
@@ -32787,7 +32830,7 @@ return /******/ (function(modules) { // webpackBootstrap
 	};
 
 /***/ }),
-/* 277 */
+/* 281 */
 /***/ (function(module, exports) {
 
 	module.exports = function(hljs) {
@@ -33197,7 +33240,7 @@ return /******/ (function(modules) { // webpackBootstrap
 	};
 
 /***/ }),
-/* 278 */
+/* 282 */
 /***/ (function(module, exports) {
 
 	module.exports = function(hljs) {
@@ -33426,7 +33469,7 @@ return /******/ (function(modules) { // webpackBootstrap
 	};
 
 /***/ }),
-/* 279 */
+/* 283 */
 /***/ (function(module, exports) {
 
 	module.exports = function(hljs) {
@@ -33512,7 +33555,7 @@ return /******/ (function(modules) { // webpackBootstrap
 	};
 
 /***/ }),
-/* 280 */
+/* 284 */
 /***/ (function(module, exports) {
 
 	module.exports = function(hljs) {
@@ -33602,7 +33645,7 @@ return /******/ (function(modules) { // webpackBootstrap
 	};
 
 /***/ }),
-/* 281 */
+/* 285 */
 /***/ (function(module, exports) {
 
 	module.exports = function(hljs) {
@@ -33625,7 +33668,7 @@ return /******/ (function(modules) { // webpackBootstrap
 	};
 
 /***/ }),
-/* 282 */
+/* 286 */
 /***/ (function(module, exports) {
 
 	module.exports = function(hljs) {
@@ -33786,7 +33829,7 @@ return /******/ (function(modules) { // webpackBootstrap
 	};
 
 /***/ }),
-/* 283 */
+/* 287 */
 /***/ (function(module, exports) {
 
 	module.exports = function(hljs) {
@@ -33815,7 +33858,7 @@ return /******/ (function(modules) { // webpackBootstrap
 	};
 
 /***/ }),
-/* 284 */
+/* 288 */
 /***/ (function(module, exports) {
 
 	module.exports = function(hljs) {
@@ -33894,7 +33937,7 @@ return /******/ (function(modules) { // webpackBootstrap
 	};
 
 /***/ }),
-/* 285 */
+/* 289 */
 /***/ (function(module, exports) {
 
 	module.exports = function(hljs) {
@@ -34010,7 +34053,7 @@ return /******/ (function(modules) { // webpackBootstrap
 	};
 
 /***/ }),
-/* 286 */
+/* 290 */
 /***/ (function(module, exports) {
 
 	module.exports = function(hljs) {
@@ -34083,7 +34126,7 @@ return /******/ (function(modules) { // webpackBootstrap
 	};
 
 /***/ }),
-/* 287 */
+/* 291 */
 /***/ (function(module, exports) {
 
 	module.exports = function(hljs) {
@@ -34180,7 +34223,7 @@ return /******/ (function(modules) { // webpackBootstrap
 	};
 
 /***/ }),
-/* 288 */
+/* 292 */
 /***/ (function(module, exports) {
 
 	module.exports = function(hljs) {
@@ -34239,7 +34282,7 @@ return /******/ (function(modules) { // webpackBootstrap
 	};
 
 /***/ }),
-/* 289 */
+/* 293 */
 /***/ (function(module, exports) {
 
 	module.exports = function(hljs) {
@@ -34292,7 +34335,7 @@ return /******/ (function(modules) { // webpackBootstrap
 	};
 
 /***/ }),
-/* 290 */
+/* 294 */
 /***/ (function(module, exports) {
 
 	module.exports = function(hljs) {
@@ -34402,7 +34445,7 @@ return /******/ (function(modules) { // webpackBootstrap
 	};
 
 /***/ }),
-/* 291 */
+/* 295 */
 /***/ (function(module, exports) {
 
 	module.exports = function(hljs) {
@@ -34497,7 +34540,7 @@ return /******/ (function(modules) { // webpackBootstrap
 	};
 
 /***/ }),
-/* 292 */
+/* 296 */
 /***/ (function(module, exports) {
 
 	module.exports = function(hljs) {
@@ -34572,7 +34615,7 @@ return /******/ (function(modules) { // webpackBootstrap
 	};
 
 /***/ }),
-/* 293 */
+/* 297 */
 /***/ (function(module, exports) {
 
 	module.exports = function(hljs) {
@@ -34633,7 +34676,7 @@ return /******/ (function(modules) { // webpackBootstrap
 	};
 
 /***/ }),
-/* 294 */
+/* 298 */
 /***/ (function(module, exports) {
 
 	module.exports = function(hljs) {
@@ -34707,7 +34750,7 @@ return /******/ (function(modules) { // webpackBootstrap
 	};
 
 /***/ }),
-/* 295 */
+/* 299 */
 /***/ (function(module, exports) {
 
 	module.exports = function(hljs) {
@@ -34759,7 +34802,7 @@ return /******/ (function(modules) { // webpackBootstrap
 	};
 
 /***/ }),
-/* 296 */
+/* 300 */
 /***/ (function(module, exports) {
 
 	module.exports = function(hljs) {
@@ -34815,7 +34858,7 @@ return /******/ (function(modules) { // webpackBootstrap
 	};
 
 /***/ }),
-/* 297 */
+/* 301 */
 /***/ (function(module, exports) {
 
 	module.exports = function(hljs) {
@@ -34946,7 +34989,7 @@ return /******/ (function(modules) { // webpackBootstrap
 	};
 
 /***/ }),
-/* 298 */
+/* 302 */
 /***/ (function(module, exports) {
 
 	module.exports = function(hljs) {
@@ -35041,7 +35084,7 @@ return /******/ (function(modules) { // webpackBootstrap
 	};
 
 /***/ }),
-/* 299 */
+/* 303 */
 /***/ (function(module, exports) {
 
 	module.exports = function(hljs) {
@@ -35126,7 +35169,7 @@ return /******/ (function(modules) { // webpackBootstrap
 	};
 
 /***/ }),
-/* 300 */
+/* 304 */
 /***/ (function(module, exports) {
 
 	module.exports = function(hljs) {
@@ -35178,7 +35221,7 @@ return /******/ (function(modules) { // webpackBootstrap
 	};
 
 /***/ }),
-/* 301 */
+/* 305 */
 /***/ (function(module, exports) {
 
 	module.exports = function(hljs) {
@@ -35212,7 +35255,7 @@ return /******/ (function(modules) { // webpackBootstrap
 	};
 
 /***/ }),
-/* 302 */
+/* 306 */
 /***/ (function(module, exports) {
 
 	module.exports = function(hljs) {
@@ -35304,7 +35347,7 @@ return /******/ (function(modules) { // webpackBootstrap
 	};
 
 /***/ }),
-/* 303 */
+/* 307 */
 /***/ (function(module, exports) {
 
 	module.exports = function(hljs) {
@@ -35344,7 +35387,7 @@ return /******/ (function(modules) { // webpackBootstrap
 	};
 
 /***/ }),
-/* 304 */
+/* 308 */
 /***/ (function(module, exports) {
 
 	module.exports = function(hljs) {
@@ -35463,7 +35506,7 @@ return /******/ (function(modules) { // webpackBootstrap
 	};
 
 /***/ }),
-/* 305 */
+/* 309 */
 /***/ (function(module, exports) {
 
 	module.exports = // Base deafult colors in PB IDE: background: #FFFFDF; foreground: #000000;
@@ -35525,7 +35568,7 @@ return /******/ (function(modules) { // webpackBootstrap
 	};
 
 /***/ }),
-/* 306 */
+/* 310 */
 /***/ (function(module, exports) {
 
 	module.exports = function(hljs) {
@@ -35645,7 +35688,7 @@ return /******/ (function(modules) { // webpackBootstrap
 	};
 
 /***/ }),
-/* 307 */
+/* 311 */
 /***/ (function(module, exports) {
 
 	module.exports = function(hljs) {
@@ -35672,7 +35715,7 @@ return /******/ (function(modules) { // webpackBootstrap
 	};
 
 /***/ }),
-/* 308 */
+/* 312 */
 /***/ (function(module, exports) {
 
 	module.exports = function(hljs) {
@@ -35845,7 +35888,7 @@ return /******/ (function(modules) { // webpackBootstrap
 	};
 
 /***/ }),
-/* 309 */
+/* 313 */
 /***/ (function(module, exports) {
 
 	module.exports = function(hljs) {
@@ -35919,7 +35962,7 @@ return /******/ (function(modules) { // webpackBootstrap
 	};
 
 /***/ }),
-/* 310 */
+/* 314 */
 /***/ (function(module, exports) {
 
 	module.exports = function(hljs) {
@@ -35950,7 +35993,7 @@ return /******/ (function(modules) { // webpackBootstrap
 	};
 
 /***/ }),
-/* 311 */
+/* 315 */
 /***/ (function(module, exports) {
 
 	module.exports = function(hljs) {
@@ -36021,7 +36064,7 @@ return /******/ (function(modules) { // webpackBootstrap
 	};
 
 /***/ }),
-/* 312 */
+/* 316 */
 /***/ (function(module, exports) {
 
 	module.exports = // Colors from RouterOS terminal:
@@ -36184,7 +36227,7 @@ return /******/ (function(modules) { // webpackBootstrap
 	};
 
 /***/ }),
-/* 313 */
+/* 317 */
 /***/ (function(module, exports) {
 
 	module.exports = function(hljs) {
@@ -36224,7 +36267,7 @@ return /******/ (function(modules) { // webpackBootstrap
 	};
 
 /***/ }),
-/* 314 */
+/* 318 */
 /***/ (function(module, exports) {
 
 	module.exports = function(hljs) {
@@ -36289,7 +36332,7 @@ return /******/ (function(modules) { // webpackBootstrap
 	};
 
 /***/ }),
-/* 315 */
+/* 319 */
 /***/ (function(module, exports) {
 
 	module.exports = function(hljs) {
@@ -36401,7 +36444,7 @@ return /******/ (function(modules) { // webpackBootstrap
 	};
 
 /***/ }),
-/* 316 */
+/* 320 */
 /***/ (function(module, exports) {
 
 	module.exports = function(hljs) {
@@ -36520,7 +36563,7 @@ return /******/ (function(modules) { // webpackBootstrap
 	};
 
 /***/ }),
-/* 317 */
+/* 321 */
 /***/ (function(module, exports) {
 
 	module.exports = function(hljs) {
@@ -36668,7 +36711,7 @@ return /******/ (function(modules) { // webpackBootstrap
 	};
 
 /***/ }),
-/* 318 */
+/* 322 */
 /***/ (function(module, exports) {
 
 	module.exports = function(hljs) {
@@ -36726,7 +36769,7 @@ return /******/ (function(modules) { // webpackBootstrap
 	};
 
 /***/ }),
-/* 319 */
+/* 323 */
 /***/ (function(module, exports) {
 
 	module.exports = function(hljs) {
@@ -36828,7 +36871,7 @@ return /******/ (function(modules) { // webpackBootstrap
 	};
 
 /***/ }),
-/* 320 */
+/* 324 */
 /***/ (function(module, exports) {
 
 	module.exports = function(hljs) {
@@ -36847,7 +36890,7 @@ return /******/ (function(modules) { // webpackBootstrap
 	};
 
 /***/ }),
-/* 321 */
+/* 325 */
 /***/ (function(module, exports) {
 
 	module.exports = function(hljs) {
@@ -36907,7 +36950,7 @@ return /******/ (function(modules) { // webpackBootstrap
 	};
 
 /***/ }),
-/* 322 */
+/* 326 */
 /***/ (function(module, exports) {
 
 	module.exports = function(hljs) {
@@ -36961,7 +37004,7 @@ return /******/ (function(modules) { // webpackBootstrap
 	};
 
 /***/ }),
-/* 323 */
+/* 327 */
 /***/ (function(module, exports) {
 
 	module.exports = function(hljs) {
@@ -37031,7 +37074,7 @@ return /******/ (function(modules) { // webpackBootstrap
 	};
 
 /***/ }),
-/* 324 */
+/* 328 */
 /***/ (function(module, exports) {
 
 	module.exports = function(hljs) {
@@ -37406,7 +37449,7 @@ return /******/ (function(modules) { // webpackBootstrap
 	};
 
 /***/ }),
-/* 325 */
+/* 329 */
 /***/ (function(module, exports) {
 
 	module.exports = function(hljs) {
@@ -37570,7 +37613,7 @@ return /******/ (function(modules) { // webpackBootstrap
 	};
 
 /***/ }),
-/* 326 */
+/* 330 */
 /***/ (function(module, exports) {
 
 	module.exports = function(hljs) {
@@ -37657,7 +37700,7 @@ return /******/ (function(modules) { // webpackBootstrap
 	};
 
 /***/ }),
-/* 327 */
+/* 331 */
 /***/ (function(module, exports) {
 
 	module.exports = function(hljs) {
@@ -37699,7 +37742,7 @@ return /******/ (function(modules) { // webpackBootstrap
 	};
 
 /***/ }),
-/* 328 */
+/* 332 */
 /***/ (function(module, exports) {
 
 	module.exports = function(hljs) {
@@ -37750,7 +37793,7 @@ return /******/ (function(modules) { // webpackBootstrap
 	};
 
 /***/ }),
-/* 329 */
+/* 333 */
 /***/ (function(module, exports) {
 
 	module.exports = function(hljs) {
@@ -38208,7 +38251,7 @@ return /******/ (function(modules) { // webpackBootstrap
 	};
 
 /***/ }),
-/* 330 */
+/* 334 */
 /***/ (function(module, exports) {
 
 	module.exports = function(hljs) {
@@ -38246,7 +38289,7 @@ return /******/ (function(modules) { // webpackBootstrap
 	};
 
 /***/ }),
-/* 331 */
+/* 335 */
 /***/ (function(module, exports) {
 
 	module.exports = function(hljs) {
@@ -38367,7 +38410,7 @@ return /******/ (function(modules) { // webpackBootstrap
 	};
 
 /***/ }),
-/* 332 */
+/* 336 */
 /***/ (function(module, exports) {
 
 	module.exports = function(hljs) {
@@ -38415,7 +38458,7 @@ return /******/ (function(modules) { // webpackBootstrap
 	};
 
 /***/ }),
-/* 333 */
+/* 337 */
 /***/ (function(module, exports) {
 
 	module.exports = function(hljs) {
@@ -38507,7 +38550,7 @@ return /******/ (function(modules) { // webpackBootstrap
 	};
 
 /***/ }),
-/* 334 */
+/* 338 */
 /***/ (function(module, exports) {
 
 	module.exports = function(hljs) {
@@ -38547,7 +38590,7 @@ return /******/ (function(modules) { // webpackBootstrap
 	};
 
 /***/ }),
-/* 335 */
+/* 339 */
 /***/ (function(module, exports) {
 
 	module.exports = function(hljs) {
@@ -38612,7 +38655,7 @@ return /******/ (function(modules) { // webpackBootstrap
 	};
 
 /***/ }),
-/* 336 */
+/* 340 */
 /***/ (function(module, exports) {
 
 	module.exports = function(hljs) {
@@ -38678,7 +38721,7 @@ return /******/ (function(modules) { // webpackBootstrap
 	};
 
 /***/ }),
-/* 337 */
+/* 341 */
 /***/ (function(module, exports) {
 
 	module.exports = function(hljs) {
@@ -38717,7 +38760,7 @@ return /******/ (function(modules) { // webpackBootstrap
 	};
 
 /***/ }),
-/* 338 */
+/* 342 */
 /***/ (function(module, exports) {
 
 	module.exports = function(hljs) {
@@ -38805,7 +38848,7 @@ return /******/ (function(modules) { // webpackBootstrap
 	};
 
 /***/ }),
-/* 339 */
+/* 343 */
 /***/ (function(module, exports) {
 
 	module.exports = function(hljs) {
@@ -38875,7 +38918,7 @@ return /******/ (function(modules) { // webpackBootstrap
 	};
 
 /***/ }),
-/* 340 */
+/* 344 */
 /***/ (function(module, exports) {
 
 	module.exports = function(hljs) {
@@ -39035,7 +39078,7 @@ return /******/ (function(modules) { // webpackBootstrap
 	};
 
 /***/ }),
-/* 341 */
+/* 345 */
 /***/ (function(module, exports) {
 
 	module.exports = function(hljs) {
@@ -39089,7 +39132,7 @@ return /******/ (function(modules) { // webpackBootstrap
 	};
 
 /***/ }),
-/* 342 */
+/* 346 */
 /***/ (function(module, exports) {
 
 	module.exports = function(hljs) {
@@ -39149,7 +39192,7 @@ return /******/ (function(modules) { // webpackBootstrap
 	};
 
 /***/ }),
-/* 343 */
+/* 347 */
 /***/ (function(module, exports) {
 
 	module.exports = function(hljs) {
@@ -39192,7 +39235,7 @@ return /******/ (function(modules) { // webpackBootstrap
 	};
 
 /***/ }),
-/* 344 */
+/* 348 */
 /***/ (function(module, exports) {
 
 	module.exports = function(hljs) {
@@ -39208,7 +39251,7 @@ return /******/ (function(modules) { // webpackBootstrap
 	};
 
 /***/ }),
-/* 345 */
+/* 349 */
 /***/ (function(module, exports) {
 
 	module.exports = function(hljs) {
@@ -39311,7 +39354,7 @@ return /******/ (function(modules) { // webpackBootstrap
 	};
 
 /***/ }),
-/* 346 */
+/* 350 */
 /***/ (function(module, exports) {
 
 	module.exports = function(hljs) {
@@ -39376,7 +39419,7 @@ return /******/ (function(modules) { // webpackBootstrap
 	};
 
 /***/ }),
-/* 347 */
+/* 351 */
 /***/ (function(module, exports) {
 
 	module.exports = function(hljs) {
@@ -39486,7 +39529,7 @@ return /******/ (function(modules) { // webpackBootstrap
 	};
 
 /***/ }),
-/* 348 */
+/* 352 */
 /***/ (function(module, exports) {
 
 	module.exports = function(hljs) {
@@ -39626,7 +39669,7 @@ return /******/ (function(modules) { // webpackBootstrap
 	};
 
 /***/ }),
-/* 349 */
+/* 353 */
 /***/ (function(module, exports) {
 
 	module.exports = function(hljs) {
@@ -39703,7 +39746,7 @@ return /******/ (function(modules) { // webpackBootstrap
 	};
 
 /***/ }),
-/* 350 */
+/* 354 */
 /***/ (function(module, exports) {
 
 	module.exports = function(hljs) {
@@ -39778,7 +39821,7 @@ return /******/ (function(modules) { // webpackBootstrap
 	};
 
 /***/ }),
-/* 351 */
+/* 355 */
 /***/ (function(module, exports) {
 
 	module.exports = function(hljs) {

--- a/example/simple/index.html
+++ b/example/simple/index.html
@@ -13,6 +13,7 @@
   <div id="app">
     <vue-markdown>The time of **NOW** is :</vue-markdown>
     <vue-markdown :source="source"></vue-markdown>
+    <vue-markdown :anchor-attributes="anchorAttrs">[A link to a website](https://google.com)</vue-markdown>
     <vue-markdown>
 SyntaxHighlighter by highlight.js:
 
@@ -46,6 +47,7 @@ function $initHighlight(block, cls) {
 
       \end{array}$$
     </vue-markdown>
+
   </div>
   <script>
     Vue.use(VueMarkdown);
@@ -53,7 +55,11 @@ function $initHighlight(block, cls) {
       el: '#app',
       data() {
         return {
-          source: new Date().toLocaleTimeString()
+          source: new Date().toLocaleTimeString(),
+          anchorAttrs: {
+            target: '_blank',
+            rel: 'noopener noreferrer nofollow'
+          }
         }
       },
       mounted () {

--- a/example/webpack-simple/src/App.vue
+++ b/example/webpack-simple/src/App.vue
@@ -2,6 +2,7 @@
   <div id="app">
     <vue-markdown>The time of **NOW** is :</vue-markdown>
     <vue-markdown :source="source"></vue-markdown>
+    <vue-markdown :anchor-attributes="anchorAttrs">[A link to a website](https://google.com)</vue-markdown>
     <vue-markdown>
 SyntaxHighlighter by highlight.js:
 
@@ -46,7 +47,11 @@ export default {
   name: 'app',
   data () {
     return {
-      source: new Date().toLocaleTimeString()
+      source: new Date().toLocaleTimeString(),
+      anchorAttrs: {
+        target: '_blank',
+        rel: 'noopener noreferrer nofollow'
+      }
     }
   },
   components: {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "vue-markdown",
-  "version": "2.1.4",
+  "version": "2.1.5",
   "description": "A Powerful and Highspeed Markdown Parser for Vue",
   "main": "dist/vue-markdown.common.js",
   "files": [

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "vue-markdown",
-  "version": "2.1.5",
+  "version": "2.2.1",
   "description": "A Powerful and Highspeed Markdown Parser for Vue",
   "main": "dist/vue-markdown.common.js",
   "files": [

--- a/src/VueMarkdown.js
+++ b/src/VueMarkdown.js
@@ -113,9 +113,9 @@ export default {
       type: String,
       default: 'toc-anchor-link',
     },
-    openLinkNewtab: {
-      type: Boolean,
-      default: true,
+    anchorAttributes: {
+      type: Object,
+      default: {}
     },
     prerender: {
       type: Function,
@@ -167,18 +167,15 @@ export default {
         return self.renderToken(tokens, idx, options)
       }
     this.md.renderer.rules.link_open = (tokens, idx, options, env, self) => {
-      if (!this.openLinkNewtab) {
-        return defaultLinkRenderer(tokens, idx, options, env, self)
-      }
-
-      let aIndex = tokens[idx].attrIndex('target')
-
-      if (aIndex < 0) {
-        tokens[idx].attrPush(['target', '_blank']) // add new attribute
-      } else {
-        tokens[idx].attrs[aIndex][1] = '_blank'
-      }
-
+      Object.keys(this.anchorAttributes).map((attribute) => {
+        let aIndex = tokens[idx].attrIndex(attribute)
+        let value = this.anchorAttributes[attribute]
+        if (aIndex < 0) {
+          tokens[idx].attrPush([attribute, value]) // add new attribute
+        } else {
+          tokens[idx].attrs[aIndex][1] = value
+        }
+      })
       return defaultLinkRenderer(tokens, idx, options, env, self)
     }
 


### PR DESCRIPTION
Purpose of this PR is to add in the ability to define attributes you want on anchor tags. The problem I am trying to solve is

1. Open links in a new tab (Solved in version 2.1.4)
2. Also protect against target="_blank" XSS attacks

To use this new attribute, it might look something like this
```
<template>
    <vue-markdown :anchorAttributes="anchorAttributes">{{ text }}</vue-markdown>
</template>
<script>
export default {
    data: () {
        anchorAttributes: {
            target: '_blank',
            rel: 'noopener noreferrer nofollow'
        }
    }
}
</script>
```

 Please comment with any suggestions or improvements you would like to see.