### PR TITLE
fix(props): Invalid default value for prop "anchorAttributes"

### DIFF
--- a/src/VueMarkdown.js
+++ b/src/VueMarkdown.js
@@ -115,7 +115,7 @@ export default {
     },
     anchorAttributes: {
       type: Object,
-      default: {}
+      default: () => ({})
     },
     prerender: {
       type: Function,


### PR DESCRIPTION
Array must use a factory function to return the default value.