### PR TITLE
Add option tag

### DIFF
--- a/src/build.js
+++ b/src/build.js
@@ -1,5 +1,9 @@
 import VueMarkdownComponent from './VueMarkdown'
 
-export function install(Vue) {
-  Vue.component('vue-markdown', VueMarkdownComponent)
+export function install(Vue, options) {
+  const _options = Object.assign({
+    tag: 'vue-markdown'
+  }, options)
+
+  Vue.component(_options.tag, VueMarkdownComponent)
 }


### PR DESCRIPTION
```js
import Vue from 'vue'
import VueMarkdown from 'vue-markdown'

Vue.use(VueMarkdown, {
  tag: 'md'
})

...
```

```html
<md>**now I can use another tag :rocket:**</md>
```

**now I can use another tag :rocket:**