### PR TITLE
Support markdown-it-toc-and-anchor's anchorLinkBefore option

### DIFF
--- a/README.md
+++ b/README.md
@@ -136,6 +136,7 @@ TIP: The default slot only renders **once** at the beginning, and it will overwr
 | toc-anchor-link-symbol | String | `#` | customize the anchor link symbol |
 | toc-anchor-link-space | Boolean | `true` | enable inserting a space between the anchor link and heading |
 | toc-anchor-link-class | String | `toc-anchor-link` | customize the anchor link symbol class name |
+| toc-anchor-link-before | Boolean | `true` | allows you to prepend/append the anchor link in the headings |
 | anchorAttributes | Object | `{}` | anchor tag attributes such as `target: '_blank'` or `rel: 'nofollow'` |
 | prerender | Function (String) String | `null` | filter function before markdown parse |
 | postrender | Function (String) String | `null` | filter function after markdown parse |

--- a/src/VueMarkdown.js
+++ b/src/VueMarkdown.js
@@ -117,6 +117,10 @@ export default {
       type: String,
       default: 'toc-anchor-link',
     },
+    tocAnchorLinkBefore: {
+      type: Boolean,
+      default: true
+    },
     anchorAttributes: {
       type: Object,
       default: () => ({})
@@ -188,6 +192,7 @@ export default {
         anchorLink: this.tocAnchorLink,
         anchorLinkSymbol: this.tocAnchorLinkSymbol,
         anchorLinkSpace: this.tocAnchorLinkSpace,
+        anchorLinkBefore: this.tocAnchorLinkBefore,
         anchorClassName: this.tocAnchorClass,
         anchorLinkSymbolClassName: this.tocAnchorLinkClass,
         tocCallback: (tocMarkdown, tocArray, tocHtml) => {


### PR DESCRIPTION
See https://github.com/medfreeman/markdown-it-toc-and-anchor#anchorlinkbefore