### PR TITLE
Add babel-runtime as an explicit dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -34,13 +34,13 @@
     "babel-plugin-transform-es2015-parameters": "^6.8.0",
     "babel-plugin-transform-runtime": "^6.8.0",
     "babel-preset-es2015": "^6.6.0",
-    "babel-runtime": "^6.6.1",
     "css-loader": "^0.23.1",
     "json-loader": "^0.5.7",
     "style-loader": "^0.13.1",
     "webpack": "^1.13.0"
   },
   "dependencies": {
+    "babel-runtime": "^6.26.0",
     "highlight.js": "^9.12.0",
     "markdown-it": "^6.0.1",
     "markdown-it-abbr": "^1.0.3",


### PR DESCRIPTION
Hello,

I have imported vue-markdown in a Laravel project. I was getting this error because I did not have installed `babel-runtime`

![Captura de pantalla 2020-04-01 a las 9 15 54](https://user-images.githubusercontent.com/6053012/78109584-c0fbcd80-73f9-11ea-93c6-60b52eeb587b.png)

`babel-runtime` should be defined as an explicit dependency.

Thank you,
