### PR TITLE
Automatically choice file in CDN: jsdelivr, unpkg 

### DIFF
--- a/package.json
+++ b/package.json
@@ -54,5 +54,7 @@
     "markdown-it-sup": "^1.0.0",
     "markdown-it-task-lists": "^2.0.1",
     "markdown-it-toc-and-anchor": "^4.1.2"
-  }
+  },
+  "jsdelivr": "dist/vue-markdown.min.js",
+  "unpkg": "dist/vue-markdown.min.js",
 }


### PR DESCRIPTION
With this changes you can use CDN like:
```html
<script src="https://cdn.jsdelivr.net/npm/vue-markdown@2.2.4"></script>
```
Now you must add path to file like:
```html
<script src="https://cdn.jsdelivr.net/npm/vue-markdown@2.2.4/dist/vue-markdown.min.js"></script>
```